### PR TITLE
Fix job number incrementing bug

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -61,15 +61,9 @@ func (js *jobService) CreateJob(ctx context.Context, jobConfig *domain.JobConfig
 		return &domain.Job{}, err
 	}
 
-	// increment and get the job number counter
-	jobNumberCounter, err := js.GetNextJobNumber(ctx)
-	if err != nil {
-		log.Error(ctx, "failed to get next job number counter", err)
-		return &domain.Job{}, appErrors.ErrInternalServerError
-	}
-
-	// Create job with label
-	job := domain.NewJob(jobConfig, jobNumberCounter.CounterValue, label)
+	// Create job with label.
+	// Set job number to 0, initially, to prevent the next consecutive number from being skipped if validation fails.
+	job := domain.NewJob(jobConfig, 0, label)
 
 	foundJobs, err := js.store.GetJobsBySourceOrTargetAndState(ctx, job.Config, domain.GetNonCancelledStates(), 1, 0)
 	if err != nil {
@@ -82,6 +76,14 @@ func (js *jobService) CreateJob(ctx context.Context, jobConfig *domain.JobConfig
 		})
 		return &domain.Job{}, appErrors.ErrJobAlreadyRunning
 	}
+
+	// increment and get the job number counter
+	jobNumberCounter, err := js.GetNextJobNumber(ctx)
+	if err != nil {
+		log.Error(ctx, "failed to get next job number counter", err)
+		return &domain.Job{}, appErrors.ErrInternalServerError
+	}
+	job.JobNumber = jobNumberCounter.CounterValue
 
 	err = js.store.CreateJob(ctx, &job)
 	if err != nil {

--- a/features/create_job.feature
+++ b/features/create_job.feature
@@ -213,6 +213,115 @@ Feature: Create a Job
         }
         """
 
+    Scenario: Create jobs with consecutive job numbers despite invalid job creation in between
+      Given a get page data request to zebedee for "/test-source-id" returns with status 200 and payload:
+        """
+        {
+          "type": "dataset_landing_page",
+          "description": {
+            "title": "Test Dataset Series"
+          }
+        }
+        """
+      And a get dataset request to the dataset API for "test-target-id" returns with status 404
+      When I POST "/v1/migration-jobs"
+        """
+        {
+          "source_id": "/test-source-id",
+          "target_id": "test-target-id",
+          "type": "static_dataset"
+        }
+        """
+      Then I should receive the following JSON response with status "202":
+        """
+        {
+          "id": "{{DYNAMIC_UUID}}",
+          "job_number":1,
+          "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+          "label": "Test Dataset Series",
+          "state": "submitted",
+          "config": {
+            "source_id": "/test-source-id",
+            "target_id": "test-target-id",
+            "type": "static_dataset"
+          },
+          "links": {
+            "self": {
+              "href": "{{DYNAMIC_URI_PATH}}"
+            },
+            "tasks": {
+              "href": "{{DYNAMIC_URI_PATH}}"
+            },
+            "events": {
+              "href": "{{DYNAMIC_URI_PATH}}"
+            }
+          }
+        }
+        """
+      When I POST "/v1/migration-jobs"
+        """
+        {
+          "source_id": "/test-source-id",
+          "target_id": "test-target-id",
+          "type": "static_dataset"
+        }
+        """
+      Then I should receive the following JSON response with status "409":
+        """
+        {
+          "errors": [
+            {
+              "code": 409,
+              "description": "job already running"
+            }
+          ]
+        }
+        """
+      Given a get page data request to zebedee for "/test-source-id-2" returns with status 200 and payload:
+        """
+        {
+          "type": "dataset_landing_page",
+          "description": {
+            "title": "Test Dataset Series"
+          }
+        }
+        """
+      And a get dataset request to the dataset API for "test-target-id-2" returns with status 404
+      When I POST "/v1/migration-jobs"
+        """
+        {
+          "source_id": "/test-source-id-2",
+          "target_id": "test-target-id-2",
+          "type": "static_dataset"
+        }
+        """
+      Then I should receive the following JSON response with status "202":
+        """
+        {
+          "id": "{{DYNAMIC_UUID}}",
+          "job_number":2,
+          "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+          "label": "Test Dataset Series",
+          "state": "submitted",
+          "config": {
+            "source_id": "/test-source-id-2",
+            "target_id": "test-target-id-2",
+            "type": "static_dataset"
+          },
+          "links": {
+            "self": {
+              "href": "{{DYNAMIC_URI_PATH}}"
+            },
+            "tasks": {
+              "href": "{{DYNAMIC_URI_PATH}}"
+            },
+            "events": {
+              "href": "{{DYNAMIC_URI_PATH}}"
+            }
+          }
+        }
+        """
+
     @StoreError
     Scenario: Create a job which is already running
       Given the following document exists in the "jobs" collection:


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/jira/software/c/projects/DIS/boards/1824?selectedIssue=DIS-4752

I've amended the migration job creation so that the job number is not incremented until after the job creation validation checks have been done. This is to fix the bug described in the ticket.

### How to review

Sense check. If you would like to check that the bug no longer occurs, then do as follows:

- Run migration stack via dp-compose
- Run a migration via POST /v1/migration-jobs. 
- Confirm that the migration job has job number 1 in the db
- Run a second migration via POST /v1/migration-jobs using the same source ID but with a new target ID
- This one should fail with 409 and a "job already running" message
- Run a third migration via POST /v1/migration-jobs using a new source ID and new target ID
- Confirm that the migration job has job number 2 in the db

The second migration should not increment the counter and so the 3rd migration should be job number 2.

### Who can review

Anyone.