### PR TITLE
Add publish functionality for a static dataset

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -183,6 +183,7 @@ func (js *jobService) ClaimJob(ctx context.Context) (*domain.Job, error) {
 		to   domain.State
 	}{
 		{from: domain.StateSubmitted, to: domain.StateMigrating},
+		{from: domain.StateApproved, to: domain.StatePublishing},
 	}
 
 	for _, tr := range transitions {

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -2396,9 +2396,11 @@ func TestClaimJob(t *testing.T) {
 			job, err := jobService.ClaimJob(ctx)
 
 			Convey("Then the store should be called to claim a job", func() {
-				So(len(mockMongo.ClaimJobCalls()), ShouldEqual, 1)
+				So(len(mockMongo.ClaimJobCalls()), ShouldEqual, 2)
 				So(mockMongo.ClaimJobCalls()[0].PendingState, ShouldEqual, domain.StateSubmitted)
 				So(mockMongo.ClaimJobCalls()[0].ActiveState, ShouldEqual, domain.StateMigrating)
+				So(mockMongo.ClaimJobCalls()[1].PendingState, ShouldEqual, domain.StateApproved)
+				So(mockMongo.ClaimJobCalls()[1].ActiveState, ShouldEqual, domain.StatePublishing)
 			})
 
 			Convey("And no error should be returned", func() {

--- a/executor/job_static_dataset.go
+++ b/executor/job_static_dataset.go
@@ -74,6 +74,31 @@ func (e *StaticDatasetJobExecutor) Migrate(ctx context.Context, job *domain.Job)
 // Publish handles the publish operations for a static dataset job.
 func (e *StaticDatasetJobExecutor) Publish(ctx context.Context, job *domain.Job) error {
 	// Implementation of publish for static dataset
+	logData := log.Data{"job_number": job.JobNumber}
+	log.Info(ctx, "starting publishing for job", logData)
+
+	totalTasks, err := e.jobService.CountTasksByJobNumber(ctx, job.JobNumber)
+	if err != nil {
+		log.Error(ctx, "failed to count tasks", err, logData)
+		return err
+	}
+
+	tasks, _, err := e.jobService.GetJobTasks(ctx, []domain.State{domain.StateInReview}, job.JobNumber, totalTasks, 0)
+	if err != nil {
+		log.Error(ctx, "failed to get job tasks", err, logData)
+		return err
+	}
+	log.Info(ctx, "successfully got all job tasks", logData)
+
+	for _, task := range tasks {
+		err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StateApproved)
+		if err != nil {
+			log.Error(ctx, "failed to update task state", err, logData)
+			return err
+		}
+	}
+	log.Info(ctx, "successfully updated all job tasks state to approved", logData)
+
 	return nil
 }
 

--- a/executor/job_static_dataset_test.go
+++ b/executor/job_static_dataset_test.go
@@ -31,6 +31,18 @@ func TestJobStaticDataset(t *testing.T) {
 			UpdateJobCollectionIDFunc: func(ctx context.Context, jobNumber int, collectionID string) error {
 				return nil
 			},
+			CountTasksByJobNumberFunc: func(ctx context.Context, jobNumber int) (int, error) {
+				return 2, nil
+			},
+			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber, limit, offset int) ([]*domain.Task, int, error) {
+				return []*domain.Task{
+					{ID: "task-1", State: domain.StateInReview},
+					{ID: "task-2", State: domain.StateInReview},
+				}, 2, nil
+			},
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error {
+				return nil
+			},
 		}
 		mockZebedeeClient := &clientMocks.ZebedeeClientMock{
 			CreateCollectionFunc: func(ctx context.Context, userAuthToken string, collection zebedee.Collection) (zebedee.Collection, error) {
@@ -74,6 +86,27 @@ func TestJobStaticDataset(t *testing.T) {
 						So(mockJobService.CreateTaskCalls()[0].Task.Source.ID, ShouldEqual, "source-dataset-id")
 						So(mockJobService.CreateTaskCalls()[0].Task.Target.ID, ShouldEqual, "target-dataset-id")
 					})
+				})
+			})
+		})
+
+		Convey("When publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePublishing,
+			}
+
+			err := executor.Publish(ctx, job)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+
+				Convey("And all tasks are updated to approved", func() {
+					So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 2)
+					So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, "task-1")
+					So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StateApproved)
+					So(mockJobService.UpdateTaskStateCalls()[1].TaskID, ShouldEqual, "task-2")
+					So(mockJobService.UpdateTaskStateCalls()[1].NewState, ShouldEqual, domain.StateApproved)
 				})
 			})
 		})
@@ -159,6 +192,105 @@ func TestJobStaticDataset(t *testing.T) {
 			Convey("Then an error is returned", func() {
 				So(err, ShouldEqual, errTest)
 				So(mockJobService.UpdateJobCollectionIDCalls(), ShouldHaveLength, 0)
+			})
+		})
+	})
+
+	Convey("Given a static dataset job executor and a job service that errors when getting tasks", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			CountTasksByJobNumberFunc: func(ctx context.Context, jobNumber int) (int, error) {
+				return 2, nil
+			},
+			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber, limit, offset int) ([]*domain.Task, int, error) {
+				return nil, 0, errTest
+			},
+		}
+
+		mockClientList := &clients.ClientList{
+			Zebedee: &clientMocks.ZebedeeClientMock{},
+		}
+
+		ctx := context.Background()
+		executor := NewStaticDatasetJobExecutor(mockJobService, mockClientList, "faketoken")
+
+		Convey("When publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePublishing,
+			}
+
+			err := executor.Publish(ctx, job)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+				So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 0)
+			})
+		})
+	})
+
+	Convey("Given a static dataset job executor and a job service that errors when updating task state", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			CountTasksByJobNumberFunc: func(ctx context.Context, jobNumber int) (int, error) {
+				return 2, nil
+			},
+			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber, limit, offset int) ([]*domain.Task, int, error) {
+				return []*domain.Task{
+					{ID: "task-1", State: domain.StateInReview},
+					{ID: "task-2", State: domain.StateInReview},
+				}, 2, nil
+			},
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error {
+				return errTest
+			},
+		}
+
+		mockClientList := &clients.ClientList{
+			Zebedee: &clientMocks.ZebedeeClientMock{},
+		}
+
+		ctx := context.Background()
+		executor := NewStaticDatasetJobExecutor(mockJobService, mockClientList, "faketoken")
+
+		Convey("When publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePublishing,
+			}
+
+			err := executor.Publish(ctx, job)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+				So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 1)
+			})
+		})
+	})
+
+	Convey("Given a static dataset job executor and a job service that errors when counting tasks", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			CountTasksByJobNumberFunc: func(ctx context.Context, jobNumber int) (int, error) {
+				return 0, errTest
+			},
+		}
+
+		mockClientList := &clients.ClientList{
+			Zebedee: &clientMocks.ZebedeeClientMock{},
+		}
+
+		ctx := context.Background()
+		executor := NewStaticDatasetJobExecutor(mockJobService, mockClientList, "faketoken")
+
+		Convey("When publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePublishing,
+			}
+
+			err := executor.Publish(ctx, job)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+				So(mockJobService.GetJobTasksCalls(), ShouldHaveLength, 0)
 			})
 		})
 	})

--- a/features/get_jobs.feature
+++ b/features/get_jobs.feature
@@ -281,11 +281,11 @@ Feature: Get list of jobs
       And the following document exists in the "jobs" collection:
         """
         {
-          "_id": "job-approved-1",
+          "_id": "job-in-review-1",
           "job_number": 21,
-          "label": "job-approved-1",
+          "label": "job-in-review-1",
           "last_updated": "2025-11-19T14:00:00Z",
-          "state": "approved",
+          "state": "in_review",
           "config": {
             "source_id": "s2",
             "target_id": "t2",
@@ -293,19 +293,19 @@ Feature: Get list of jobs
           }
         }
         """
-      When I GET "/v1/migration-jobs?state=migrating&state=approved"
+      When I GET "/v1/migration-jobs?state=migrating&state=in_review"
       Then I should receive the following JSON response with status "200":
         """
         {
           "count": 2,
           "items": [
             {
-              "id": "job-approved-1",
+              "id": "job-in-review-1",
               "job_number": 21,
-              "label": "job-approved-1",
+              "label": "job-in-review-1",
               "last_updated": "2025-11-19T14:00:00Z",
               "links": {},
-              "state": "approved",
+              "state": "in_review",
               "config": {
                 "source_id": "s2",
                 "target_id": "t2",
@@ -351,11 +351,11 @@ Feature: Get list of jobs
       And the following document exists in the "jobs" collection:
         """
         {
-          "_id": "job-approved-1",
+          "_id": "job-in-review-1",
           "job_number": 2,
-          "label": "job-approved-1",
+          "label": "job-in-review-1",
           "last_updated": "2025-11-19T14:00:00Z",
-          "state": "approved",
+          "state": "in_review",
           "config": {
             "source_id": "s2",
             "target_id": "t2",
@@ -363,19 +363,19 @@ Feature: Get list of jobs
           }
         }
         """
-      When I GET "/v1/migration-jobs?state=migrating,approved"
+      When I GET "/v1/migration-jobs?state=migrating,in_review"
       Then I should receive the following JSON response with status "200":
         """
         {
           "count": 2,
           "items": [
             {
-              "id": "job-approved-1",
+              "id": "job-in-review-1",
               "job_number": 2,
-              "label": "job-approved-1",
+              "label": "job-in-review-1",
               "last_updated": "2025-11-19T14:00:00Z",
               "links": {},
-              "state": "approved",
+              "state": "in_review",
               "config": {
                 "source_id": "s2",
                 "target_id": "t2",

--- a/features/publish_static_dataset.feature
+++ b/features/publish_static_dataset.feature
@@ -1,0 +1,126 @@
+@Publish @PublishStaticDataset
+Feature: Publish a static dataset job
+
+  Background:
+     Given an admin user has the following permissions as JSON:
+        """
+        {
+            "migrations:read": {
+                "groups/role-admin": [{"id": "1"}]
+            },
+            "migrations:edit": {
+                "groups/role-admin": [{"id": "1"}]
+            }
+        }
+        """
+     And I am an admin user
+     And the migration service is running
+
+
+  Scenario: Publish a static dataset job
+    Given the following document exists in the "jobs" collection:
+      """
+      {
+        "_id": "3985ff0f-2d46-51gg-022g-6b33f8173802",
+        "job_number": 30,
+        "last_updated": "2025-11-19T13:28:00Z",
+        "links": {
+          "self": {
+            "href": "/v1/migration-jobs/30"
+          }
+        },
+        "state": "in_review",
+        "label": "Test Publish Dataset Series",
+        "config": {
+          "source_id": "/test-static-dataset-job",
+          "target_id": "test-target-id",
+          "type": "static_dataset"
+        }
+      }
+      """
+    And the following document exists in the "tasks" collection:
+      """
+      {
+        "_id": "task-223e4567-e89b-12d3-a456-426614174000",
+        "job_number": 30,
+        "last_updated": "2025-11-19T13:30:00Z",
+        "state": "in_review",
+        "type": "dataset_series",
+        "source": {
+          "id": "/test-static-dataset-job"
+        },
+        "target": {
+          "id": "test-target-id"
+        },
+        "links": {
+          "self": {
+            "href": "/v1/migration-jobs/30/tasks/task-223e4567-e89b-12d3-a456-426614174000"
+          },
+          "job": {
+            "href": "/v1/migration-jobs/30"
+          }
+        }
+      }
+      """
+    When I PUT "/v1/migration-jobs/30/state"
+      """
+      {
+        "state": "approved"
+      }
+      """
+    Then the HTTP status code should be "204"
+    And I wait 2 seconds for the job processor to process tasks and jobs
+    When I GET "/v1/migration-jobs/30"
+    Then I should receive the following JSON response with status "200":
+      """
+      {
+        "id": "3985ff0f-2d46-51gg-022g-6b33f8173802",
+        "job_number": 30,
+        "state": "publishing",
+        "last_updated": "{{DYNAMIC_TIMESTAMP}}",
+        "config": {
+          "source_id": "/test-static-dataset-job",
+          "target_id": "test-target-id",
+          "type": "static_dataset"
+        },
+        "label": "Test Publish Dataset Series",
+        "links": {
+          "self": {
+            "href": "/v1/migration-jobs/30"
+          }
+        }
+      }
+      """
+    When I GET "/v1/migration-jobs/30/tasks"
+    Then I should receive the following JSON response with status "200":
+      """
+      {
+        "items": [
+          {
+            "id": "task-223e4567-e89b-12d3-a456-426614174000",
+            "job_number": 30,
+            "type": "dataset_series",
+            "state": "approved",
+            "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+            "links": {
+              "self": {
+                "href": "/v1/migration-jobs/30/tasks/task-223e4567-e89b-12d3-a456-426614174000"
+              },
+              "job": {
+                "href": "/v1/migration-jobs/30"
+              }
+            },
+            "source": {
+              "id": "/test-static-dataset-job"
+            },
+            "target": {
+              "id": "test-target-id"
+            }
+          }
+        ],
+        "count": 1,
+        "total_count": 1,
+        "offset": 0,
+        "limit": 10
+      }
+      """

--- a/migrator/jobs.go
+++ b/migrator/jobs.go
@@ -99,6 +99,8 @@ func (mig *migrator) executeJob(ctx context.Context, job *domain.Job) {
 		switch job.State {
 		case domain.StateMigrating:
 			err = jobExecutor.Migrate(ctx, job)
+		case domain.StatePublishing:
+			err = jobExecutor.Publish(ctx, job)
 		default:
 			err = fmt.Errorf("unsupported job state: %s", job.State)
 			log.Error(ctx, "unsupported job state for execution", err, logData)

--- a/migrator/jobs_test.go
+++ b/migrator/jobs_test.go
@@ -46,6 +46,9 @@ func TestMigratorExecuteJob(t *testing.T) {
 			MigrateFunc: func(ctx context.Context, job *domain.Job) error {
 				return nil
 			},
+			PublishFunc: func(ctx context.Context, job *domain.Job) error {
+				return nil
+			},
 		}
 
 		getJobExecutors = func(_ application.JobService, _ *clients.ClientList, _ *config.Config) map[domain.JobType]executor.JobExecutor {
@@ -106,6 +109,24 @@ func TestMigratorExecuteJob(t *testing.T) {
 
 			Convey("Then the executor is not called to migrate", func() {
 				So(len(mockJobExecutor.MigrateCalls()), ShouldEqual, 0)
+			})
+		})
+
+		Convey("When a job in state publishing is executed", func() {
+			job := &domain.Job{
+				JobNumber: fakeJobNumber,
+				Config: &domain.JobConfig{
+					Type: fakeJobType,
+				},
+				State: domain.StatePublishing,
+			}
+
+			mig.executeJob(ctx, job)
+			mig.wg.Wait()
+
+			Convey("Then the executor is called to publish", func() {
+				So(len(mockJobExecutor.PublishCalls()), ShouldEqual, 1)
+				So(mockJobExecutor.PublishCalls()[0].Job.JobNumber, ShouldEqual, fakeJobNumber)
 			})
 		})
 	})
@@ -202,6 +223,60 @@ func TestMigratorExecuteJob(t *testing.T) {
 			Convey("Then the job is failed", func() {
 				So(len(mockJobService.UpdateJobStateCalls()), ShouldEqual, 1)
 				So(mockJobService.UpdateJobStateCalls()[0].NewState, ShouldEqual, domain.StateFailedMigration)
+			})
+		})
+	})
+
+	Convey("Given a migrator with an executor that fails to publish the job", t, func() {
+		mockJobExecutor := &executorMocks.JobExecutorMock{
+			MigrateFunc: func(ctx context.Context, job *domain.Job) error {
+				return nil
+			},
+			PublishFunc: func(ctx context.Context, job *domain.Job) error {
+				return errors.New("publish error")
+			},
+		}
+
+		getJobExecutors = func(_ application.JobService, _ *clients.ClientList, _ *config.Config) map[domain.JobType]executor.JobExecutor {
+			return map[domain.JobType]executor.JobExecutor{
+				fakeJobType: mockJobExecutor,
+			}
+		}
+
+		mockJobService := &applicationMocks.JobServiceMock{
+			UpdateJobStateFunc: func(ctx context.Context, jobNumber int, state domain.State, userID string) error {
+				return nil
+			},
+			GetNextJobNumberFunc: func(ctx context.Context) (*domain.Counter, error) {
+				fakeCounter := domain.Counter{}
+				return &fakeCounter, nil
+			},
+		}
+
+		mockClients := &clients.ClientList{}
+		mockSlackClient := createMockSlackClient()
+		cfg := &config.Config{
+			MigratorMaxConcurrentExecutions: 1,
+		}
+
+		topicCache, _ := cache.NewPopulatedTopicCacheForTest(context.Background())
+		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, topicCache)
+		ctx := context.Background()
+
+		Convey("When a job is executed that errors during publishing", func() {
+			job := &domain.Job{
+				JobNumber: fakeJobNumber,
+				State:     domain.StatePublishing,
+				Config: &domain.JobConfig{
+					Type: fakeJobType,
+				},
+			}
+			mig.executeJob(ctx, job)
+			mig.wg.Wait()
+
+			Convey("Then the job is failed", func() {
+				So(len(mockJobService.UpdateJobStateCalls()), ShouldEqual, 1)
+				So(mockJobService.UpdateJobStateCalls()[0].NewState, ShouldEqual, domain.StateFailedPublish)
 			})
 		})
 	})


### PR DESCRIPTION
### What

[Add publish functionality for a static dataset](https://officefornationalstatistics.atlassian.net/browse/DIS-4340?atlOrigin=eyJpIjoiZWMxYjIxN2VkY2I3NDY5ODk3NjM1OTFjNmY3ZTRjMTQiLCJwIjoiaiJ9)

adjusted the states in get_jobs.feature as jobs in state `approved` will move to `publishing` causing the test to fail

### How to review

Sense check

**Optionally**
- Pull this branch
- Run the migration stack
- Post the demo job
- make a PUT request to update the job's state once it's `in_review`:

`http://localhost:30100/v1/migration-jobs/1/state`
with the body being:
`{
    "state": "approved"
}`

- GET the job, and it's state should now be `publishing`
- Get the tasks `http://localhost:30100/v1/migration-jobs/1/tasks` and they should now be `approved`

### Who can review

not me