### PR TITLE
Add Trace IDs to Jobs and Tasks

### DIFF
--- a/migrator/jobs.go
+++ b/migrator/jobs.go
@@ -74,17 +74,18 @@ func (mig *migrator) monitorJobs(ctx context.Context) {
 				}
 			}
 
-			requestID := dpRequest.NewRequestID(RequestIDLength)
-			ctx = dpRequest.WithRequestId(context.Background(), requestID)
 			log.Info(ctx, "claimed job", log.Data{"job_id": job.ID, "job_state": job.State})
-			mig.executeJob(ctx, job)
+			mig.executeJob(job)
 		}
 	}
 }
 
 // executeJob executes the provided job in a separate goroutine based on
 // it's state
-func (mig *migrator) executeJob(ctx context.Context, job *domain.Job) {
+func (mig *migrator) executeJob(job *domain.Job) {
+	requestID := dpRequest.NewRequestID(RequestIDLength)
+	ctx := dpRequest.WithRequestId(context.Background(), requestID)
+	log.Info(ctx, "executing job", log.Data{"job_id": job.ID, "job_state": job.State})
 	mig.wg.Add(1)
 	go func() {
 		defer mig.wg.Done()

--- a/migrator/jobs.go
+++ b/migrator/jobs.go
@@ -41,7 +41,7 @@ var getJobExecutors = func(jobService application.JobService, appClients *client
 	return jobExecutors
 }
 
-func (mig *migrator) getJobExecutor(ctx context.Context, job *domain.Job) (executor.JobExecutor, error) {
+func (mig *migrator) getJobExecutor(job *domain.Job) (executor.JobExecutor, error) {
 	jobExecutor := mig.jobExecutors[job.Config.Type]
 	if jobExecutor == nil {
 		return nil, fmt.Errorf("no executor found for task type: %s", job.Config.Type)
@@ -99,7 +99,7 @@ func (mig *migrator) executeJob(job *domain.Job) {
 			return
 		}
 
-		jobExecutor, err := mig.getJobExecutor(ctx, job)
+		jobExecutor, err := mig.getJobExecutor(job)
 		if err != nil {
 			log.Error(ctx, "failed to get job executor", err, logData)
 			_ = mig.failJob(ctx, job, err, failureReasonExecutorMissing)

--- a/migrator/jobs.go
+++ b/migrator/jobs.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	dpRequest "github.com/ONSdigital/dp-net/v3/request"
+
 	"github.com/ONSdigital/dis-migration-service/application"
 	"github.com/ONSdigital/dis-migration-service/clients"
 	"github.com/ONSdigital/dis-migration-service/config"
@@ -26,6 +28,11 @@ const (
 	EventUpdateJobStateFailed = "Failed to update job state"
 	// EventUpdateTaskStateFailed is sent when updating a task state fails.
 	EventUpdateTaskStateFailed = "Failed to update task state"
+
+	// RequestIDLength is the length of the request id, which is needed
+	// for creating a trace_id. It is set to 20 for consistency with the
+	// request id length used in log.go
+	RequestIDLength = 20
 )
 
 var getJobExecutors = func(jobService application.JobService, appClients *clients.ClientList, cfg *config.Config) map[domain.JobType]executor.JobExecutor {
@@ -67,6 +74,8 @@ func (mig *migrator) monitorJobs(ctx context.Context) {
 				}
 			}
 
+			requestID := dpRequest.NewRequestID(RequestIDLength)
+			ctx = dpRequest.WithRequestId(context.Background(), requestID)
 			log.Info(ctx, "claimed job", log.Data{"job_id": job.ID, "job_state": job.State})
 			mig.executeJob(ctx, job)
 		}

--- a/migrator/jobs_test.go
+++ b/migrator/jobs_test.go
@@ -75,7 +75,6 @@ func TestMigratorExecuteJob(t *testing.T) {
 
 		topicCache, _ := cache.NewPopulatedTopicCacheForTest(context.Background())
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, topicCache)
-		ctx := context.Background()
 
 		Convey("When a job in state migrating is executed", func() {
 			job := &domain.Job{
@@ -86,7 +85,7 @@ func TestMigratorExecuteJob(t *testing.T) {
 				State: domain.StateMigrating,
 			}
 
-			mig.executeJob(ctx, job)
+			mig.executeJob(job)
 			mig.wg.Wait()
 
 			Convey("Then the executor is called to migrate", func() {
@@ -104,7 +103,7 @@ func TestMigratorExecuteJob(t *testing.T) {
 				State: "unknown-state",
 			}
 
-			mig.executeJob(ctx, job)
+			mig.executeJob(job)
 			mig.wg.Wait()
 
 			Convey("Then the executor is not called to migrate", func() {
@@ -121,7 +120,7 @@ func TestMigratorExecuteJob(t *testing.T) {
 				State: domain.StatePublishing,
 			}
 
-			mig.executeJob(ctx, job)
+			mig.executeJob(job)
 			mig.wg.Wait()
 
 			Convey("Then the executor is called to publish", func() {
@@ -154,7 +153,6 @@ func TestMigratorExecuteJob(t *testing.T) {
 
 		topicCache, _ := cache.NewPopulatedTopicCacheForTest(context.Background())
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, topicCache)
-		ctx := context.Background()
 
 		Convey("When a job is executed", func() {
 			job := &domain.Job{
@@ -165,7 +163,7 @@ func TestMigratorExecuteJob(t *testing.T) {
 				State: domain.StateMigrating,
 			}
 
-			mig.executeJob(ctx, job)
+			mig.executeJob(job)
 			mig.wg.Wait()
 
 			Convey("Then the job is marked as failed", func() {
@@ -207,7 +205,6 @@ func TestMigratorExecuteJob(t *testing.T) {
 
 		topicCache, _ := cache.NewPopulatedTopicCacheForTest(context.Background())
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, topicCache)
-		ctx := context.Background()
 
 		Convey("When a job is executed that errors during migration", func() {
 			job := &domain.Job{
@@ -217,7 +214,7 @@ func TestMigratorExecuteJob(t *testing.T) {
 					Type: fakeJobType,
 				},
 			}
-			mig.executeJob(ctx, job)
+			mig.executeJob(job)
 			mig.wg.Wait()
 
 			Convey("Then the job is failed", func() {
@@ -261,7 +258,6 @@ func TestMigratorExecuteJob(t *testing.T) {
 
 		topicCache, _ := cache.NewPopulatedTopicCacheForTest(context.Background())
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, topicCache)
-		ctx := context.Background()
 
 		Convey("When a job is executed that errors during publishing", func() {
 			job := &domain.Job{
@@ -271,7 +267,7 @@ func TestMigratorExecuteJob(t *testing.T) {
 					Type: fakeJobType,
 				},
 			}
-			mig.executeJob(ctx, job)
+			mig.executeJob(job)
 			mig.wg.Wait()
 
 			Convey("Then the job is failed", func() {

--- a/migrator/jobs_test.go
+++ b/migrator/jobs_test.go
@@ -389,7 +389,6 @@ func TestGetJobExecutor(t *testing.T) {
 
 		topicCache, _ := cache.NewPopulatedTopicCacheForTest(context.Background())
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, topicCache)
-		ctx := context.Background()
 
 		Convey("When getJobExecutor is called for a job with a known type", func() {
 			job := &domain.Job{
@@ -398,7 +397,7 @@ func TestGetJobExecutor(t *testing.T) {
 				},
 			}
 
-			jobExecutor, err := mig.getJobExecutor(ctx, job)
+			jobExecutor, err := mig.getJobExecutor(job)
 
 			Convey("Then the correct executor is returned", func() {
 				So(err, ShouldBeNil)
@@ -413,7 +412,7 @@ func TestGetJobExecutor(t *testing.T) {
 				},
 			}
 
-			jobExecutor, err := mig.getJobExecutor(ctx, job)
+			jobExecutor, err := mig.getJobExecutor(job)
 
 			Convey("Then an error is returned", func() {
 				So(err, ShouldNotBeNil)

--- a/migrator/tasks.go
+++ b/migrator/tasks.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	dpRequest "github.com/ONSdigital/dp-net/v3/request"
+
 	"github.com/ONSdigital/dis-migration-service/application"
 	"github.com/ONSdigital/dis-migration-service/cache"
 	"github.com/ONSdigital/dis-migration-service/clients"
@@ -26,7 +28,7 @@ var getTaskExecutors = func(jobService application.JobService, appClients *clien
 	return taskExecutors
 }
 
-func (mig *migrator) getTaskExecutor(ctx context.Context, task *domain.Task) (executor.TaskExecutor, error) {
+func (mig *migrator) getTaskExecutor(task *domain.Task) (executor.TaskExecutor, error) {
 	taskExecutor := mig.taskExecutors[task.Type]
 	if taskExecutor == nil {
 		return nil, fmt.Errorf("no executor found for task type: %s", task.Type)
@@ -59,13 +61,16 @@ func (mig *migrator) monitorTasks(ctx context.Context) {
 				}
 			}
 			log.Info(ctx, "claimed task", log.Data{"task_id": task.ID, "task_state": task.State})
-			mig.executeTask(ctx, task)
+			mig.executeTask(task)
 		}
 	}
 }
 
 // executeTask executes a task based on its state
-func (mig *migrator) executeTask(ctx context.Context, task *domain.Task) {
+func (mig *migrator) executeTask(task *domain.Task) {
+	requestID := dpRequest.NewRequestID(RequestIDLength)
+	ctx := dpRequest.WithRequestId(context.Background(), requestID)
+	log.Info(ctx, "executing task", log.Data{"task_id": task.ID, "task_state": task.State})
 	mig.wg.Add(1)
 	go func() {
 		defer mig.wg.Done()
@@ -79,7 +84,7 @@ func (mig *migrator) executeTask(ctx context.Context, task *domain.Task) {
 			return
 		}
 
-		taskExecutor, err := mig.getTaskExecutor(ctx, task)
+		taskExecutor, err := mig.getTaskExecutor(task)
 		if err != nil {
 			log.Error(ctx, "failed to get task executor", err, logData)
 			_ = mig.failTask(ctx, task, err, failureReasonExecutorMissing)

--- a/migrator/tasks_test.go
+++ b/migrator/tasks_test.go
@@ -67,7 +67,6 @@ func TestMigratorExecuteTask(t *testing.T) {
 		}
 
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, mockTopicCache)
-		ctx := context.Background()
 
 		Convey("When a task in state migrating is executed", func() {
 			task := &domain.Task{
@@ -77,7 +76,7 @@ func TestMigratorExecuteTask(t *testing.T) {
 				State:     domain.StateMigrating,
 			}
 
-			mig.executeTask(ctx, task)
+			mig.executeTask(task)
 			mig.wg.Wait()
 
 			Convey("Then the executor is called to migrate", func() {
@@ -92,7 +91,7 @@ func TestMigratorExecuteTask(t *testing.T) {
 				State: "unknown-state",
 			}
 
-			mig.executeTask(ctx, task)
+			mig.executeTask(task)
 			mig.wg.Wait()
 
 			Convey("Then the executor is not called to migrate", func() {
@@ -140,7 +139,6 @@ func TestMigratorExecuteTask(t *testing.T) {
 		}
 
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, mockTopicCache)
-		ctx := context.Background()
 
 		Convey("When a task is executed", func() {
 			task := &domain.Task{
@@ -148,7 +146,7 @@ func TestMigratorExecuteTask(t *testing.T) {
 				State: domain.StateMigrating,
 			}
 
-			mig.executeTask(ctx, task)
+			mig.executeTask(task)
 			mig.wg.Wait()
 
 			Convey("Then the task is failed", func() {
@@ -202,7 +200,6 @@ func TestMigratorExecuteTask(t *testing.T) {
 		}
 
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, mockTopicCache)
-		ctx := context.Background()
 
 		Convey("When a task is executed that errors during migration", func() {
 			task := &domain.Task{
@@ -210,7 +207,7 @@ func TestMigratorExecuteTask(t *testing.T) {
 				Type:      fakeTaskType,
 				State:     domain.StateMigrating,
 			}
-			mig.executeTask(ctx, task)
+			mig.executeTask(task)
 			mig.wg.Wait()
 
 			Convey("Then the task is failed", func() {
@@ -337,14 +334,13 @@ func TestGetTaskExecutor(t *testing.T) {
 
 		topicCache, _ := cache.NewPopulatedTopicCacheForTest(context.Background())
 		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, topicCache)
-		ctx := context.Background()
 
 		Convey("When getTaskExecutor is called for a task with a known type", func() {
 			task := &domain.Task{
 				Type: fakeTaskType,
 			}
 
-			taskExecutor, err := mig.getTaskExecutor(ctx, task)
+			taskExecutor, err := mig.getTaskExecutor(task)
 
 			Convey("Then the correct executor is returned", func() {
 				So(err, ShouldBeNil)
@@ -357,7 +353,7 @@ func TestGetTaskExecutor(t *testing.T) {
 				Type: "unknown-task-type",
 			}
 
-			taskExecutor, err := mig.getTaskExecutor(ctx, task)
+			taskExecutor, err := mig.getTaskExecutor(task)
 
 			Convey("Then an error is returned", func() {
 				So(err, ShouldNotBeNil)


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/jira/software/c/projects/DIS/boards/1824?selectedIssue=DIS-4783

When an execution starts, a trace_id should be generated and assigned to the context in a similar way to how the routers do this for http requests.

### How to review

Create a migration (e.g. using the migration stack). Check the logs in the migration service. You should see things like this, which log trace_id values:

dis-migration-service-1  | {
dis-migration-service-1  |   "created_at": "2026-04-30T11:19:46.024858334Z",
dis-migration-service-1  |   "data": {
dis-migration-service-1  |     "job_id": "7eaf28a2-2b85-4c2c-b90d-95128082cfdc",
dis-migration-service-1  |     "job_state": "migrating"
dis-migration-service-1  |   },
dis-migration-service-1  |   "event": "executing job",
dis-migration-service-1  |   "namespace": "dis-migration-service",
dis-migration-service-1  |   "severity": 3,
dis-migration-service-1  |   "trace_id": "mEwEHrwkNKRjKWGquske"
dis-migration-service-1  | }

dis-migration-service-1  | {
dis-migration-service-1  |   "created_at": "2026-04-30T11:20:01.041395287Z",
dis-migration-service-1  |   "data": {
dis-migration-service-1  |     "task_id": "bed73531-fbff-45c8-b109-b8ab04ca3002",
dis-migration-service-1  |     "task_state": "migrating"
dis-migration-service-1  |   },
dis-migration-service-1  |   "event": "executing task",
dis-migration-service-1  |   "namespace": "dis-migration-service",
dis-migration-service-1  |   "severity": 3,
dis-migration-service-1  |   "trace_id": "hvfWoJyoIoAKxSToaPXB"
dis-migration-service-1  | }

When a task is executed, all logs associated to that task execution should have the same trace_id
When a job is executed, all logs associated to that job execution should have the same trace_id

When a task sends requests to another Go service (e.g. dp-dataset-api, dp-upload-service), the logs associated with that http request, should also have the same trace_id. This won't be the case with Java apps.

NB. If a migration successfully creates a dataset then the following kinds of migration tasks should have matching trace_ids in the dataset api and upload service respectively:

dis-migration-service-1  | {
dis-migration-service-1  |   "created_at": "2026-04-30T11:19:51.01659186Z",
dis-migration-service-1  |   "data": {
dis-migration-service-1  |     "job_number": 2,
dis-migration-service-1  |     "task_id": "d2c5834d-0e84-462f-9747-bf7f38412b6e"
dis-migration-service-1  |   },
dis-migration-service-1  |   "event": "starting migration for dataset series task",
dis-migration-service-1  |   "namespace": "dis-migration-service",
dis-migration-service-1  |   "severity": 3,
dis-migration-service-1  |   "trace_id": "ouybBzbsznQOnawuCMMy"
dis-migration-service-1  | }

dis-migration-service-1  | {
dis-migration-service-1  |   "created_at": "2026-04-30T11:20:06.048148573Z",
dis-migration-service-1  |   "data": {
dis-migration-service-1  |     "job_number": 2,
dis-migration-service-1  |     "source_id": "/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputeslabourdisputesannualestimates/latestversion/previous/v4/dataset12017.xls",
dis-migration-service-1  |     "task_id": "e0705dee-ad18-4080-b527-9486fa1b0c59"
dis-migration-service-1  |   },
dis-migration-service-1  |   "event": "starting migration for dataset download task",
dis-migration-service-1  |   "namespace": "dis-migration-service",
dis-migration-service-1  |   "severity": 3,
dis-migration-service-1  |   "trace_id": "WoouPehQdEuDjjnigyTW"
dis-migration-service-1  | }

### Who can review

Anyone
