### PR TITLE
Add Publish Functionality for a Dataset Download Task

### DIFF
--- a/executor/task_dataset_download.go
+++ b/executor/task_dataset_download.go
@@ -136,6 +136,15 @@ func (e *DatasetDownloadTaskExecutor) Migrate(ctx context.Context, task *domain.
 // Publish handles the publish operations for a dataset download task.
 func (e *DatasetDownloadTaskExecutor) Publish(ctx context.Context, task *domain.Task) error {
 	// Implementation of publish for dataset download
+	logData := log.Data{"task_id": task.ID, "job_number": task.JobNumber}
+	log.Info(ctx, "starting publish for dataset download task", logData)
+
+	err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StatePublished)
+	if err != nil {
+		log.Error(ctx, "failed to update publish task", err, logData)
+		return err
+	}
+	log.Info(ctx, "completed publish for dataset download task", logData)
 	return nil
 }
 

--- a/executor/task_dataset_download_test.go
+++ b/executor/task_dataset_download_test.go
@@ -131,6 +131,20 @@ func TestDatasetDownloadTaskExecutor(t *testing.T) {
 					})
 				})
 			})
+
+			Convey("When publish is called for a download task", func() {
+				err := executor.Publish(ctx, testDownloadTask)
+
+				Convey("Then no error is returned", func() {
+					So(err, ShouldBeNil)
+
+					Convey("And the task state is updated to Published", func() {
+						So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 1)
+						So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, testDownloadTask.ID)
+						So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StatePublished)
+					})
+				})
+			})
 		})
 
 		Convey("And a dataset download task executor with a zebedee client mock that errors", func() {


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/jira/software/c/projects/DIS/boards/1824?selectedIssue=DIS-3962

In order for a dataset download task (part of a migration job) to be published, the publish functionality will need to be triggered. This PR implements the publish functionality, for a dataset download task, and adds a unit test for it.

How to review
Sense check. Tests pass.

Who can review
Anyone.