### PR TITLE
Add Publish Functionality for a Dataset Edition Task

### DIFF
--- a/executor/task_dataset_edition.go
+++ b/executor/task_dataset_edition.go
@@ -100,6 +100,15 @@ func (e *DatasetEditionTaskExecutor) Migrate(ctx context.Context, task *domain.T
 // Publish handles the publish operations for a dataset edition task.
 func (e *DatasetEditionTaskExecutor) Publish(ctx context.Context, task *domain.Task) error {
 	// Implementation of publish for dataset edition
+	logData := log.Data{"task_id": task.ID, "job_number": task.JobNumber}
+	log.Info(ctx, "starting publish for dataset edition task", logData)
+
+	err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StatePublished)
+	if err != nil {
+		log.Error(ctx, "failed to update publish task", err, logData)
+		return err
+	}
+	log.Info(ctx, "completed publish for dataset edition task", logData)
 	return nil
 }
 

--- a/executor/task_dataset_edition_test.go
+++ b/executor/task_dataset_edition_test.go
@@ -88,6 +88,20 @@ func TestDatasetEditionTaskExecutor(t *testing.T) {
 				})
 			})
 		})
+
+		Convey("When publish is called for a task", func() {
+			err := executor.Publish(ctx, testEditionTask)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+
+				Convey("And the task state is updated to Published", func() {
+					So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 1)
+					So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, testEditionTask.ID)
+					So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StatePublished)
+				})
+			})
+		})
 	})
 
 	Convey("Given a dataset edition task executor with a zebedee client mock that returns a dataset with multiple versions", t, func() {


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/jira/software/c/projects/DIS/boards/1824?selectedIssue=DIS-3960

In order for a dataset edition task (part of a migration job) to be published, the publish functionality will need to be triggered. This PR implements the publish functionality, for a dataset edition task, and adds a unit test for it.

How to review
Sense check. Tests pass.

Who can review
Anyone.