### PR TITLE
Add publish to version task execution

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -259,6 +259,7 @@ func (js *jobService) ClaimTask(ctx context.Context) (*domain.Task, error) {
 		to   domain.State
 	}{
 		{from: domain.StateSubmitted, to: domain.StateMigrating},
+		{from: domain.StateApproved, to: domain.StatePublishing},
 	}
 
 	for _, tr := range transitions {

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -2475,9 +2475,11 @@ func TestClaimTask(t *testing.T) {
 			task, err := jobService.ClaimTask(ctx)
 
 			Convey("Then the store should be called to claim a task", func() {
-				So(len(mockMongo.ClaimTaskCalls()), ShouldEqual, 1)
+				So(len(mockMongo.ClaimTaskCalls()), ShouldEqual, 2)
 				So(mockMongo.ClaimTaskCalls()[0].PendingState, ShouldEqual, domain.StateSubmitted)
 				So(mockMongo.ClaimTaskCalls()[0].ActiveState, ShouldEqual, domain.StateMigrating)
+				So(mockMongo.ClaimTaskCalls()[1].PendingState, ShouldEqual, domain.StateApproved)
+				So(mockMongo.ClaimTaskCalls()[1].ActiveState, ShouldEqual, domain.StatePublishing)
 			})
 
 			Convey("And no error should be returned", func() {

--- a/executor/task_dataset_version.go
+++ b/executor/task_dataset_version.go
@@ -3,14 +3,22 @@ package executor
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/ONSdigital/dis-migration-service/application"
 	"github.com/ONSdigital/dis-migration-service/clients"
 	"github.com/ONSdigital/dis-migration-service/domain"
 	"github.com/ONSdigital/dis-migration-service/mapper"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	datasetModels "github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/sdk"
 	"github.com/ONSdigital/log.go/v2/log"
+)
+
+// These could be abstracted to config later if desired.
+const (
+	versionPublishPollMaxRetries = 10
+	versionPublishPollDelay      = 500 * time.Millisecond
 )
 
 // DatasetVersionTaskExecutor executes migration tasks for dataset versions.
@@ -172,7 +180,58 @@ func (e *DatasetVersionTaskExecutor) Migrate(ctx context.Context, task *domain.T
 
 // Publish handles the publish operations for a dataset version task.
 func (e *DatasetVersionTaskExecutor) Publish(ctx context.Context, task *domain.Task) error {
-	// Implementation of publish for dataset version
+	logData := log.Data{"task_id": task.ID, "job_number": task.JobNumber}
+
+	log.Info(ctx, "starting publish for dataset version task", logData)
+
+	headers := sdk.Headers{
+		AccessToken: e.serviceAuthToken,
+	}
+
+	err := e.clientList.DatasetAPI.PutVersionState(ctx, headers, task.Target.DatasetID, task.Target.EditionID, task.Target.ID, datasetModels.ApprovedState)
+	if err != nil {
+		log.Error(ctx, "failed to update dataset version state to approved", err, logData)
+		return err
+	}
+
+	err = e.clientList.DatasetAPI.PutVersionState(ctx, headers, task.Target.DatasetID, task.Target.EditionID, task.Target.ID, datasetModels.PublishedState)
+	if err != nil {
+		log.Error(ctx, "failed to update dataset version state to published", err, logData)
+		return err
+	}
+
+	for attempt := 1; attempt <= versionPublishPollMaxRetries; attempt++ {
+		if attempt > 1 {
+			log.Info(ctx, "version not yet published, retrying", log.Data{
+				"attempt": attempt,
+				"delay":   versionPublishPollDelay.String(),
+			}, logData)
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(versionPublishPollDelay):
+			}
+		}
+		version, err := e.clientList.DatasetAPI.GetVersion(ctx, headers, task.Target.DatasetID, task.Target.EditionID, task.Target.ID)
+		if err != nil {
+			log.Error(ctx, "failed to get dataset version", err, logData)
+			return err
+		}
+
+		if version.State == datasetModels.PublishedState {
+			log.Info(ctx, "dataset version is now published", logData)
+			break
+		}
+	}
+
+	// Mark task as complete
+	err = e.jobService.UpdateTaskState(ctx, task.ID, domain.StatePublished)
+	if err != nil {
+		log.Error(ctx, "failed to update migration task", err, logData)
+		return err
+	}
+	log.Info(ctx, "completed migration for dataset version task", logData)
 	return nil
 }
 

--- a/executor/task_dataset_version_test.go
+++ b/executor/task_dataset_version_test.go
@@ -36,7 +36,7 @@ func generateFileName(n int) string {
 	return "file" + strconv.Itoa(n) + ".csv"
 }
 
-func TestDatasetVersionTaskExecutor(t *testing.T) {
+func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 	Convey("Given a job service and datasetAPI clients that don't error", t, func() {
 		mockJobService := &applicationMocks.JobServiceMock{
 			CreateTaskFunc: func(ctx context.Context, jobNumber int, task *domain.Task) (*domain.Task, error) {
@@ -658,6 +658,173 @@ func TestDatasetVersionTaskExecutor(t *testing.T) {
 					So(len(mockJobService.CreateTaskCalls()), ShouldEqual, 1)
 				})
 			})
+		})
+	})
+}
+
+func TestDatasetVersionTaskExecutorPublish(t *testing.T) {
+	Convey("Given a dataset version task executor and a dataset API client that succeeds on first poll", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error { return nil },
+		}
+
+		mockDatasetClient := &datasetSDKMock.ClienterMock{
+			PutVersionStateFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID, state string) error {
+				return nil
+			},
+			GetVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string) (models.Version, error) {
+				return models.Version{State: models.PublishedState}, nil
+			},
+		}
+
+		ctx := context.Background()
+
+		executor := NewDatasetVersionTaskExecutor(mockJobService, &clients.ClientList{
+			DatasetAPI: mockDatasetClient,
+		}, testServiceAuthToken)
+
+		err := executor.Publish(ctx, testVersionTask)
+
+		Convey("Then no error is returned", func() {
+			So(err, ShouldBeNil)
+			So(len(mockDatasetClient.PutVersionStateCalls()), ShouldEqual, 2)
+			So(mockDatasetClient.PutVersionStateCalls()[0].State, ShouldEqual, models.ApprovedState)
+			So(mockDatasetClient.PutVersionStateCalls()[1].State, ShouldEqual, models.PublishedState)
+			So(len(mockDatasetClient.GetVersionCalls()), ShouldEqual, 1)
+			So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 1)
+			So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StatePublished)
+		})
+	})
+
+	Convey("Given a dataset version task executor and a dataset API client that succeeds on the 3rd poll", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error { return nil },
+		}
+
+		callCount := 0
+		mockDatasetClient := &datasetSDKMock.ClienterMock{
+			PutVersionStateFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID, state string) error {
+				return nil
+			},
+			GetVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string) (models.Version, error) {
+				callCount++
+				if callCount < 3 {
+					return models.Version{State: models.ApprovedState}, nil
+				}
+				return models.Version{State: models.PublishedState}, nil
+			},
+		}
+
+		ctx := context.Background()
+
+		executor := NewDatasetVersionTaskExecutor(mockJobService, &clients.ClientList{
+			DatasetAPI: mockDatasetClient,
+		}, testServiceAuthToken)
+
+		err := executor.Publish(ctx, testVersionTask)
+
+		Convey("Then no error is returned and polling occurs successfully", func() {
+			So(err, ShouldBeNil)
+			So(len(mockDatasetClient.GetVersionCalls()), ShouldEqual, 3)
+			So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 1)
+		})
+	})
+
+	Convey("Given a dataset version task executor and a dataset API client that fails to set approved state", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{}
+		mockDatasetClient := &datasetSDKMock.ClienterMock{
+			PutVersionStateFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID, state string) error {
+				return errTest
+			},
+		}
+
+		ctx := context.Background()
+
+		executor := NewDatasetVersionTaskExecutor(mockJobService, &clients.ClientList{
+			DatasetAPI: mockDatasetClient,
+		}, testServiceAuthToken)
+
+		err := executor.Publish(ctx, testVersionTask)
+
+		Convey("Then an error is returned and no further calls happen", func() {
+			So(err, ShouldEqual, errTest)
+			So(len(mockDatasetClient.PutVersionStateCalls()), ShouldEqual, 1)
+			So(len(mockDatasetClient.GetVersionCalls()), ShouldEqual, 0)
+		})
+	})
+
+	Convey("Given a dataset version task executor and a dataset API client that fails to set published state", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{}
+		mockDatasetClient := &datasetSDKMock.ClienterMock{
+			PutVersionStateFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID, state string) error {
+				return errTest
+			},
+		}
+
+		ctx := context.Background()
+
+		executor := NewDatasetVersionTaskExecutor(mockJobService, &clients.ClientList{
+			DatasetAPI: mockDatasetClient,
+		}, testServiceAuthToken)
+
+		err := executor.Publish(ctx, testVersionTask)
+
+		Convey("Then an error is returned and polling does not start", func() {
+			So(err, ShouldEqual, errTest)
+			So(len(mockDatasetClient.PutVersionStateCalls()), ShouldEqual, 1)
+			So(len(mockDatasetClient.GetVersionCalls()), ShouldEqual, 0)
+		})
+	})
+
+	Convey("Given a dataset version task executor and a dataset API client that fails to get version", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{}
+		mockDatasetClient := &datasetSDKMock.ClienterMock{
+			PutVersionStateFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID, state string) error {
+				return nil
+			},
+			GetVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string) (models.Version, error) {
+				return models.Version{}, errTest
+			},
+		}
+
+		ctx := context.Background()
+
+		executor := NewDatasetVersionTaskExecutor(mockJobService, &clients.ClientList{
+			DatasetAPI: mockDatasetClient,
+		}, testServiceAuthToken)
+
+		err := executor.Publish(ctx, testVersionTask)
+
+		Convey("Then an error is returned and polling stops", func() {
+			So(err, ShouldEqual, errTest)
+			So(len(mockDatasetClient.GetVersionCalls()), ShouldEqual, 1)
+		})
+	})
+
+	Convey("Given a dataset version task executor and a store that fails to update task state", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error { return errTest },
+		}
+		mockDatasetClient := &datasetSDKMock.ClienterMock{
+			PutVersionStateFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID, state string) error {
+				return nil
+			},
+			GetVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string) (models.Version, error) {
+				return models.Version{State: models.PublishedState}, nil
+			},
+		}
+
+		ctx := context.Background()
+
+		executor := NewDatasetVersionTaskExecutor(mockJobService, &clients.ClientList{
+			DatasetAPI: mockDatasetClient,
+		}, testServiceAuthToken)
+
+		err := executor.Publish(ctx, testVersionTask)
+
+		Convey("Then an error is returned", func() {
+			So(err, ShouldEqual, errTest)
+			So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 1)
 		})
 	})
 }

--- a/features/publish_static_dataset.feature
+++ b/features/publish_static_dataset.feature
@@ -77,7 +77,7 @@ Feature: Publish a static dataset job
       {
         "id": "3985ff0f-2d46-51gg-022g-6b33f8173802",
         "job_number": 30,
-        "state": "publishing",
+        "state": "published",
         "last_updated": "{{DYNAMIC_TIMESTAMP}}",
         "config": {
           "collection_id": "migration-job-test-collection",
@@ -102,7 +102,7 @@ Feature: Publish a static dataset job
             "id": "task-223e4567-e89b-12d3-a456-426614174000",
             "job_number": 30,
             "type": "dataset_series",
-            "state": "approved",
+            "state": "published",
             "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
             "links": {
               "self": {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/ONSdigital/dp-otel-go v0.0.8
 	github.com/ONSdigital/dp-permissions-api v1.11.0
 	github.com/ONSdigital/dp-topic-api v1.3.1
-	github.com/ONSdigital/dp-upload-service v1.15.0
+	github.com/ONSdigital/dp-upload-service v1.16.0
 	github.com/ONSdigital/log.go/v2 v2.5.2
 	github.com/cucumber/godog v0.15.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/ONSdigital/dp-s3/v3 v3.3.0 h1:l5QrJ4lFHMfhHmk0Cox+0xSNQ6RhkCHJ6ikqq5X
 github.com/ONSdigital/dp-s3/v3 v3.3.0/go.mod h1:KT4ZL+3p3RDYv4zfgAKXb4ofPey2eDUFZKk0E/c/jr4=
 github.com/ONSdigital/dp-topic-api v1.3.1 h1:rnYeiZPRM7vrA1k75OCw4a7ZGAfsM9gbqew+/eJlb88=
 github.com/ONSdigital/dp-topic-api v1.3.1/go.mod h1:5mUuCGbkfpTFpTY2Nt1PeJ4CGvvPzS5A74/3kN34A1w=
-github.com/ONSdigital/dp-upload-service v1.15.0 h1:vzFbbQ+QbhrXWm7WYRpKCISBa0brwMpkUy6DO46ysRE=
-github.com/ONSdigital/dp-upload-service v1.15.0/go.mod h1:m9se46D8a2hEy+iGAqPk31IeZXQSgtzL2F8lPVh084o=
+github.com/ONSdigital/dp-upload-service v1.16.0 h1:d5d3JLVNZcXRPEgWQ4VUBln4DtSEQAnFpkThX6yuBaw=
+github.com/ONSdigital/dp-upload-service v1.16.0/go.mod h1:wNpO98KJoogXl+skjsCgzJHKFsixEupzoKZQxOvi+WU=
 github.com/ONSdigital/log.go/v2 v2.5.2 h1:V6NYtbi+thHYTwckxOXPklZUgQCNBo1/fyPPIutu4V4=
 github.com/ONSdigital/log.go/v2 v2.5.2/go.mod h1:KZNEweCUHD8dKwhlvoRvgd2Y2aUIuU3H9/MmbFyVzW8=
 github.com/Shopify/sarama v1.38.1 h1:lqqPUPQZ7zPqYlWpTh+LQ9bhYNu2xJL6k1SJN4WVe2A=

--- a/mapper/download.go
+++ b/mapper/download.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/ONSdigital/dis-migration-service/domain"
@@ -27,7 +28,7 @@ func MapResourceToUploadServiceMetadata(uri, datasetID, edition, version string,
 	// isPublishable is currently always true for migrated files.
 	isPublishable := true
 	uploadMetadata := uploadAPI.Metadata{
-		Path:          uuid.New().String(),
+		Path:          fmt.Sprintf("%s/%s", uuid.New().String(), filepath.Base(uri)),
 		IsPublishable: &isPublishable,
 		DatasetID:     datasetID,
 		Edition:       edition,

--- a/mapper/download_test.go
+++ b/mapper/download_test.go
@@ -27,6 +27,7 @@ func TestMapResourceToUploadServiceMetadata(t *testing.T) {
 			})
 
 			Convey("Then the metadata fields are mapped correctly", func() {
+				So(metadata.Path, ShouldContainSubstring, "testfile.csv")
 				So(metadata.Title, ShouldEqual, "testfile.csv")
 				So(metadata.SizeInBytes, ShouldEqual, int64(2048))
 				So(metadata.Type, ShouldEqual, "text/csv")

--- a/migrator/tasks.go
+++ b/migrator/tasks.go
@@ -95,7 +95,7 @@ func (mig *migrator) executeTask(task *domain.Task) {
 		switch task.State {
 		case domain.StateMigrating:
 			err = taskExecutor.Migrate(ctx, task)
-		case domain.StateApproved:
+		case domain.StatePublishing:
 			err = taskExecutor.Publish(ctx, task)
 		default:
 			err = fmt.Errorf("unsupported task state: %s", task.State)


### PR DESCRIPTION
### What

Add publish to version task execution - with a few little tidy ups around the side.

N.B. I have hardcoded the re-try config for now, the current upper bounds are in the milliseconds so this should be ample.

### How to review

Check looks ok - optionally to test you can:

1. run the migration stack
2. run the test migration
3. approve the test migration
4. observe that it publishes successfully

### Who can review

Not me. 