### PR TITLE
populate latest_version links during migration

### DIFF
--- a/executor/task_dataset_version.go
+++ b/executor/task_dataset_version.go
@@ -140,7 +140,13 @@ func (e *DatasetVersionTaskExecutor) Migrate(ctx context.Context, task *domain.T
 
 	log.Info(ctx, "creating dataset version in dataset API", logData)
 
-	_, err = e.clientList.DatasetAPI.PostVersion(ctx, headers, task.Target.DatasetID, task.Target.EditionID, task.Target.ID, *datasetVersion)
+	// Populating latest_version
+	isLatest := false
+	if len(seriesData.Datasets) > 0 {
+		isLatest = editionData.URI == seriesData.Datasets[0].URI && datasetVersion.Version == len(editionData.Versions)+1
+	}
+
+	_, err = e.clientList.DatasetAPI.PostVersion(ctx, headers, task.Target.DatasetID, task.Target.EditionID, task.Target.ID, *datasetVersion, isLatest)
 	if err != nil {
 		log.Error(ctx, "failed to create target dataset version in dataset API", err, logData)
 		return err

--- a/executor/task_dataset_version_test.go
+++ b/executor/task_dataset_version_test.go
@@ -54,7 +54,7 @@ func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 		}
 
 		mockDatasetClient := &datasetSDKMock.ClienterMock{
-			PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version) (*models.Version, error) {
+			PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version, isLatest bool) (*models.Version, error) {
 				return &models.Version{}, nil
 			},
 		}
@@ -103,6 +103,7 @@ func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 						So(mockDatasetClient.PostVersionCalls()[0].EditionID, ShouldEqual, testEditionID)
 						So(mockDatasetClient.PostVersionCalls()[0].VersionID, ShouldEqual, "1")
 						So(mockDatasetClient.PostVersionCalls()[0].Headers.AccessToken, ShouldEqual, testServiceAuthToken)
+						So(mockDatasetClient.PostVersionCalls()[0].IsLatest, ShouldBeFalse)
 
 						Convey("And the zebedee client is called to complete and approve the collection content", func() {
 							So(len(mockClientList.Zebedee.(*clientMocks.ZebedeeClientMock).SaveContentToCollectionCalls()), ShouldEqual, 1)
@@ -191,6 +192,108 @@ func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 							So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, testVersionTask.ID)
 							So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StateInReview)
 						})
+					})
+				})
+			})
+		})
+
+		Convey("And a zebedee client that returns a dataset where the current version is the latest version", func() {
+			mockClientList := &clients.ClientList{
+				DatasetAPI: mockDatasetClient,
+				Zebedee: &clientMocks.ZebedeeClientMock{
+					GetDatasetFunc: func(ctx context.Context, userAccessToken, collectionID, lang, path string) (zebedee.Dataset, error) {
+						return zebedee.Dataset{
+							Type: zebedee.PageTypeDataset,
+							URI:  testEditionURI,
+							Versions: []zebedee.Version{
+								{URI: testEditionURI + "/previous/v1"},
+								{URI: testEditionURI + "/previous/v2"},
+							},
+						}, nil
+					},
+					GetDatasetLandingPageFunc: func(ctx context.Context, userAccessToken, collectionID, lang, path string) (zebedee.DatasetLandingPage, error) {
+						return zebedee.DatasetLandingPage{
+							Type: zebedee.PageTypeDatasetLandingPage,
+							Datasets: []zebedee.Link{
+								{URI: testEditionURI},
+							},
+						}, nil
+					},
+					SaveContentToCollectionFunc: func(ctx context.Context, userAuthToken, collectionID, path string, content interface{}) error {
+						return nil
+					},
+					CompleteCollectionContentFunc: func(ctx context.Context, userAccessToken, collectionID, lang, pagePath string) error {
+						return nil
+					},
+					ApproveCollectionContentFunc: func(ctx context.Context, userAccessToken, collectionID, lang, pagePath string) error {
+						return nil
+					},
+				},
+			}
+
+			ctx := context.Background()
+			executor := NewDatasetVersionTaskExecutor(mockJobService, mockClientList, testServiceAuthToken)
+
+			Convey("When migrate is called for a task", func() {
+				err := executor.Migrate(ctx, testVersionTask)
+
+				Convey("Then no error is returned", func() {
+					So(err, ShouldBeNil)
+
+					Convey("And PostVersion is called with isLatest=true", func() {
+						So(len(mockDatasetClient.PostVersionCalls()), ShouldEqual, 1)
+						So(mockDatasetClient.PostVersionCalls()[0].IsLatest, ShouldBeTrue)
+					})
+				})
+			})
+		})
+
+		Convey("And a zebedee client that returns a dataset where the current version is not the latest version", func() {
+			mockClientList := &clients.ClientList{
+				DatasetAPI: mockDatasetClient,
+				Zebedee: &clientMocks.ZebedeeClientMock{
+					GetDatasetFunc: func(ctx context.Context, userAccessToken, collectionID, lang, path string) (zebedee.Dataset, error) {
+						return zebedee.Dataset{
+							Type: zebedee.PageTypeDataset,
+							URI:  testEditionURI,
+							Versions: []zebedee.Version{
+								{URI: testEditionURI + "/previous/v1"},
+								{URI: testEditionURI + "/previous/v2"},
+							},
+						}, nil
+					},
+					GetDatasetLandingPageFunc: func(ctx context.Context, userAccessToken, collectionID, lang, path string) (zebedee.DatasetLandingPage, error) {
+						return zebedee.DatasetLandingPage{
+							Type: zebedee.PageTypeDatasetLandingPage,
+							Datasets: []zebedee.Link{
+								{URI: "/some-other-edition-uri"},
+							},
+						}, nil
+					},
+					SaveContentToCollectionFunc: func(ctx context.Context, userAuthToken, collectionID, path string, content interface{}) error {
+						return nil
+					},
+					CompleteCollectionContentFunc: func(ctx context.Context, userAccessToken, collectionID, lang, pagePath string) error {
+						return nil
+					},
+					ApproveCollectionContentFunc: func(ctx context.Context, userAccessToken, collectionID, lang, pagePath string) error {
+						return nil
+					},
+				},
+			}
+
+			ctx := context.Background()
+			executor := NewDatasetVersionTaskExecutor(mockJobService, mockClientList, testServiceAuthToken)
+
+			Convey("When migrate is called for a task", func() {
+				err := executor.Migrate(ctx, testVersionTask)
+
+				Convey("Then no error is returned", func() {
+					So(err, ShouldBeNil)
+
+					Convey("And PostVersion is called with isLatest=false", func() {
+						So(len(mockDatasetClient.PostVersionCalls()), ShouldEqual, 1)
+						So(mockDatasetClient.PostVersionCalls()[0].IsLatest, ShouldBeFalse)
 					})
 				})
 			})
@@ -369,7 +472,7 @@ func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 
 		mockClientList := &clients.ClientList{
 			DatasetAPI: &datasetSDKMock.ClienterMock{
-				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version) (*models.Version, error) {
+				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version, isLatest bool) (*models.Version, error) {
 					return &models.Version{}, nil
 				},
 			},
@@ -432,7 +535,7 @@ func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 
 		mockClientList := &clients.ClientList{
 			DatasetAPI: &datasetSDKMock.ClienterMock{
-				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version) (*models.Version, error) {
+				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version, isLatest bool) (*models.Version, error) {
 					return &models.Version{}, nil
 				},
 			},
@@ -471,7 +574,7 @@ func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 		}
 		mockClientList := &clients.ClientList{
 			DatasetAPI: &datasetSDKMock.ClienterMock{
-				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version) (*models.Version, error) {
+				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version, isLatest bool) (*models.Version, error) {
 					return &models.Version{}, errTest
 				},
 			},
@@ -546,7 +649,7 @@ func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 		}
 		mockClientList := &clients.ClientList{
 			DatasetAPI: &datasetSDKMock.ClienterMock{
-				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version) (*models.Version, error) {
+				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version, isLatest bool) (*models.Version, error) {
 					return &models.Version{}, nil
 				},
 			},
@@ -610,7 +713,7 @@ func TestDatasetVersionTaskExecutorMigrate(t *testing.T) {
 		}
 		mockClientList := &clients.ClientList{
 			DatasetAPI: &datasetSDKMock.ClienterMock{
-				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version) (*models.Version, error) {
+				PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID, editionID, versionID string, version models.Version, isLatest bool) (*models.Version, error) {
 					return &models.Version{}, nil
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-authorisation/v2 v2.34.0
 	github.com/ONSdigital/dp-cache v0.6.1
 	github.com/ONSdigital/dp-component-test v1.4.4-alpha
-	github.com/ONSdigital/dp-dataset-api v1.102.0
+	github.com/ONSdigital/dp-dataset-api v1.106.0
 	github.com/ONSdigital/dp-files-api v1.19.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-mongodb/v3 v3.13.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/ONSdigital/dp-cache v0.6.1 h1:wiYvxRIef9nu3Uk1//il5vNLTeKgajZ2kYacwkF
 github.com/ONSdigital/dp-cache v0.6.1/go.mod h1:d95JP5gBSNE0L206aNvFDtI1m0oTEGWN9ZetmnN/7hk=
 github.com/ONSdigital/dp-component-test v1.4.4-alpha h1:efo71nub0AQZO5Bxp8X5As7xytBl60qSHC/FAm08DME=
 github.com/ONSdigital/dp-component-test v1.4.4-alpha/go.mod h1:Wm4JPH5/xyehThk1zbVZ3EKizPl7PefzheFG2e2PYoo=
-github.com/ONSdigital/dp-dataset-api v1.102.0 h1:+Kxy2Y0DiFPbDt1s9xT7VBwKvpE34CmhMlKW3ytP43Q=
-github.com/ONSdigital/dp-dataset-api v1.102.0/go.mod h1:t1ayvaWA56WTdEBzYbA7DytmJVxktilnfA2WznRZI/E=
+github.com/ONSdigital/dp-dataset-api v1.106.0 h1:Nn+PaEWBH7l22QCMxuh/jELVKoZj8TF25Co8jjmnHtI=
+github.com/ONSdigital/dp-dataset-api v1.106.0/go.mod h1:AK2gpeRf6MrfnWgyXTM3M13SK+9ECzuQhst/kL7LrmE=
 github.com/ONSdigital/dp-files-api v1.19.0 h1:C82idvRAliq1f5KIBOML7/h1rH5E1AXwK2DJUbjlBL4=
 github.com/ONSdigital/dp-files-api v1.19.0/go.mod h1:ajampl7S6Scswy70qQT73OwHPq0Cak9CQHmXHXMG0pU=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=


### PR DESCRIPTION
### What

[populate latest_version links during migration](https://officefornationalstatistics.atlassian.net/browse/DIS-4660?atlOrigin=eyJpIjoiYzczZDlmN2ZhZTY0NDQ5MWFjYTk4OWM4OTk4MzViZTQiLCJwIjoiaiJ9)

### How to review

sense check

**optionally:**
- pull this branch
- run the migration stack
- post the demo job
- do a GET request to the dataset-api (`http://localhost:22000/datasets`)
- check in the `links` of the dataset -> 'latest_version' should now be populated

### Who can review

not me