### PR TITLE
Fix bug where job number is always 0 in links

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	sort "github.com/ONSdigital/dis-migration-service/api/sort"
@@ -83,7 +84,10 @@ func (js *jobService) CreateJob(ctx context.Context, jobConfig *domain.JobConfig
 		log.Error(ctx, "failed to get next job number counter", err)
 		return &domain.Job{}, appErrors.ErrInternalServerError
 	}
-	job.JobNumber = jobNumberCounter.CounterValue
+	jobNumber := jobNumberCounter.CounterValue
+	job.JobNumber = jobNumber
+	links := domain.NewJobLinks(strconv.Itoa(jobNumber))
+	job.Links = links
 
 	err = js.store.CreateJob(ctx, &job)
 	if err != nil {

--- a/application/application.go
+++ b/application/application.go
@@ -83,7 +83,7 @@ func (js *jobService) CreateJob(ctx context.Context, jobConfig *domain.JobConfig
 		log.Error(ctx, "failed to get next job number counter", err)
 		return &domain.Job{}, appErrors.ErrInternalServerError
 	}
-	job = domain.SetJobNumber(jobNumberCounter.CounterValue, job)
+	job.SetJobNumber(jobNumberCounter.CounterValue)
 
 	err = js.store.CreateJob(ctx, &job)
 	if err != nil {

--- a/application/application.go
+++ b/application/application.go
@@ -3,7 +3,6 @@ package application
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	sort "github.com/ONSdigital/dis-migration-service/api/sort"
@@ -84,10 +83,7 @@ func (js *jobService) CreateJob(ctx context.Context, jobConfig *domain.JobConfig
 		log.Error(ctx, "failed to get next job number counter", err)
 		return &domain.Job{}, appErrors.ErrInternalServerError
 	}
-	jobNumber := jobNumberCounter.CounterValue
-	job.JobNumber = jobNumber
-	links := domain.NewJobLinks(strconv.Itoa(jobNumber))
-	job.Links = links
+	job = domain.SetJobNumber(jobNumberCounter.CounterValue, job)
 
 	err = js.store.CreateJob(ctx, &job)
 	if err != nil {

--- a/domain/job.go
+++ b/domain/job.go
@@ -57,3 +57,14 @@ func NewJobLinks(jobNumber string) JobLinks {
 		},
 	}
 }
+
+// SetJobNumber updates the Job provided, including its JobLinks, with the
+// new job number provided
+// @newJobNumber the new number for the job
+// @job the job to update
+func SetJobNumber(newJobNumber int, job Job) Job {
+	job.JobNumber = newJobNumber
+	links := NewJobLinks(strconv.Itoa(newJobNumber))
+	job.Links = links
+	return job
+}

--- a/domain/job.go
+++ b/domain/job.go
@@ -58,13 +58,11 @@ func NewJobLinks(jobNumber string) JobLinks {
 	}
 }
 
-// SetJobNumber updates the Job provided, including its JobLinks, with the
-// new job number provided
+// SetJobNumber updates the Job, including its JobLinks, with the new job
+// number provided
 // @newJobNumber the new number for the job
-// @job the job to update
-func SetJobNumber(newJobNumber int, job Job) Job {
-	job.JobNumber = newJobNumber
+func (j *Job) SetJobNumber(newJobNumber int) {
+	j.JobNumber = newJobNumber
 	links := NewJobLinks(strconv.Itoa(newJobNumber))
-	job.Links = links
-	return job
+	j.Links = links
 }

--- a/features/create_job.feature
+++ b/features/create_job.feature
@@ -41,13 +41,13 @@ Feature: Create a Job
           },
           "links": {
             "self": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0"
             },
             "tasks": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0/tasks"
             },
             "events": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0/events"
             }
           }
         }
@@ -247,13 +247,13 @@ Feature: Create a Job
           },
           "links": {
             "self": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0"
             },
             "tasks": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0/tasks"
             },
             "events": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0/events"
             }
           }
         }
@@ -310,13 +310,13 @@ Feature: Create a Job
           },
           "links": {
             "self": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0"
             },
             "tasks": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0/tasks"
             },
             "events": {
-              "href": "{{DYNAMIC_URI_PATH}}"
+              "href": "/v1/migration-jobs/0/events"
             }
           }
         }

--- a/features/create_job.feature
+++ b/features/create_job.feature
@@ -41,13 +41,13 @@ Feature: Create a Job
           },
           "links": {
             "self": {
-              "href": "/v1/migration-jobs/0"
+              "href": "/v1/migration-jobs/1"
             },
             "tasks": {
-              "href": "/v1/migration-jobs/0/tasks"
+              "href": "/v1/migration-jobs/1/tasks"
             },
             "events": {
-              "href": "/v1/migration-jobs/0/events"
+              "href": "/v1/migration-jobs/1/events"
             }
           }
         }
@@ -247,13 +247,13 @@ Feature: Create a Job
           },
           "links": {
             "self": {
-              "href": "/v1/migration-jobs/0"
+              "href": "/v1/migration-jobs/1"
             },
             "tasks": {
-              "href": "/v1/migration-jobs/0/tasks"
+              "href": "/v1/migration-jobs/1/tasks"
             },
             "events": {
-              "href": "/v1/migration-jobs/0/events"
+              "href": "/v1/migration-jobs/1/events"
             }
           }
         }
@@ -310,13 +310,13 @@ Feature: Create a Job
           },
           "links": {
             "self": {
-              "href": "/v1/migration-jobs/0"
+              "href": "/v1/migration-jobs/2"
             },
             "tasks": {
-              "href": "/v1/migration-jobs/0/tasks"
+              "href": "/v1/migration-jobs/2/tasks"
             },
             "events": {
-              "href": "/v1/migration-jobs/0/events"
+              "href": "/v1/migration-jobs/2/events"
             }
           }
         }


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4830

There was a bug that meant the links in the migration jobs always had a job number of 0 in them e.g.

```json
"links" : {
    "self" : {
        "href" : "/v1/migration-jobs/0"
    },
    "tasks" : {
        "href" : "/v1/migration-jobs/0/tasks"
    },
    "events" : {
        "href" : "/v1/migration-jobs/0/events"
    }
 }
```

### How to review

- Run the migration stack
- Call the POST localhost:30100/v1/migration-jobs endpoint e.g. using a body like this:

```json
{
   "source_id": "/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputeslabourdisputesannualestimates",
   "target_id": "bug-fix-test",
   "type": "static_dataset"
}
```

- Check that the JSON in the response has the correct job number (not 0) in its links. E.g.
```json
{
    "id": "e50562e4-103a-4518-8171-0c79560c28df",
    "job_number": 1,
    "label": "Labour disputes, annual estimates, UK",
    "last_updated": "2026-05-15T14:36:43.970413728Z",
    "state": "submitted",
    "config": {
        "source_id": "/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputeslabourdisputesannualestimates",
        "target_id": "bug-fix-test",
        "type": "static_dataset"
    },
    "links": {
        "self": {
            "href": "/v1/migration-jobs/1"
        },
        "tasks": {
            "href": "/v1/migration-jobs/1/tasks"
        },
        "events": {
            "href": "/v1/migration-jobs/1/events"
        }
    }
}
```
### Who can review

Anyone.