### PR TITLE
add post publish functionality for a migrated dataset

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -209,6 +209,7 @@ func (js *jobService) ClaimJob(ctx context.Context) (*domain.Job, error) {
 	}{
 		{from: domain.StateSubmitted, to: domain.StateMigrating},
 		{from: domain.StateApproved, to: domain.StatePublishing},
+		{from: domain.StatePublished, to: domain.StatePostPublishing},
 		{from: domain.StateRejected, to: domain.StateReverting},
 	}
 	for _, tr := range transitions {

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -2626,13 +2626,15 @@ func TestClaimJob(t *testing.T) {
 			job, err := jobService.ClaimJob(ctx)
 
 			Convey("Then the store should be called to claim a job", func() {
-				So(len(mockMongo.ClaimJobCalls()), ShouldEqual, 3)
+				So(len(mockMongo.ClaimJobCalls()), ShouldEqual, 4)
 				So(mockMongo.ClaimJobCalls()[0].PendingState, ShouldEqual, domain.StateSubmitted)
 				So(mockMongo.ClaimJobCalls()[0].ActiveState, ShouldEqual, domain.StateMigrating)
 				So(mockMongo.ClaimJobCalls()[1].PendingState, ShouldEqual, domain.StateApproved)
 				So(mockMongo.ClaimJobCalls()[1].ActiveState, ShouldEqual, domain.StatePublishing)
-				So(mockMongo.ClaimJobCalls()[2].PendingState, ShouldEqual, domain.StateRejected)
-				So(mockMongo.ClaimJobCalls()[2].ActiveState, ShouldEqual, domain.StateReverting)
+				So(mockMongo.ClaimJobCalls()[2].PendingState, ShouldEqual, domain.StatePublished)
+				So(mockMongo.ClaimJobCalls()[2].ActiveState, ShouldEqual, domain.StatePostPublishing)
+				So(mockMongo.ClaimJobCalls()[3].PendingState, ShouldEqual, domain.StateRejected)
+				So(mockMongo.ClaimJobCalls()[3].ActiveState, ShouldEqual, domain.StateReverting)
 			})
 			Convey("And no error should be returned", func() {
 				So(err, ShouldBeNil)

--- a/clients/interfaces.go
+++ b/clients/interfaces.go
@@ -35,5 +35,6 @@ type ZebedeeClient interface {
 	GetFileSize(ctx context.Context, authToken, collectionID, lang, uri string) (f zebedee.FileSize, err error)
 	GetPageData(ctx context.Context, authToken, collectionID, lang, path string) (m zebedee.PageData, err error)
 	GetResourceStream(ctx context.Context, authToken, collectionID, lang, path string) (s io.ReadCloser, err error)
+	PublishCollection(ctx context.Context, authToken, collectionID string) error
 	SaveContentToCollection(ctx context.Context, authToken, collectionID, path string, content interface{}) error
 }

--- a/clients/mock/zebedee.go
+++ b/clients/mock/zebedee.go
@@ -57,6 +57,9 @@ var _ clients.ZebedeeClient = &ZebedeeClientMock{}
 //			GetResourceStreamFunc: func(ctx context.Context, authToken string, collectionID string, lang string, path string) (io.ReadCloser, error) {
 //				panic("mock out the GetResourceStream method")
 //			},
+//			PublishCollectionFunc: func(ctx context.Context, authToken string, collectionID string) error {
+//				panic("mock out the PublishCollection method")
+//			},
 //			SaveContentToCollectionFunc: func(ctx context.Context, authToken string, collectionID string, path string, content interface{}) error {
 //				panic("mock out the SaveContentToCollection method")
 //			},
@@ -102,6 +105,9 @@ type ZebedeeClientMock struct {
 
 	// GetResourceStreamFunc mocks the GetResourceStream method.
 	GetResourceStreamFunc func(ctx context.Context, authToken string, collectionID string, lang string, path string) (io.ReadCloser, error)
+
+	// PublishCollectionFunc mocks the PublishCollection method.
+	PublishCollectionFunc func(ctx context.Context, authToken string, collectionID string) error
 
 	// SaveContentToCollectionFunc mocks the SaveContentToCollection method.
 	SaveContentToCollectionFunc func(ctx context.Context, authToken string, collectionID string, path string, content interface{}) error
@@ -246,6 +252,15 @@ type ZebedeeClientMock struct {
 			// Path is the path argument value.
 			Path string
 		}
+		// PublishCollection holds details about calls to the PublishCollection method.
+		PublishCollection []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// AuthToken is the authToken argument value.
+			AuthToken string
+			// CollectionID is the collectionID argument value.
+			CollectionID string
+		}
 		// SaveContentToCollection holds details about calls to the SaveContentToCollection method.
 		SaveContentToCollection []struct {
 			// Ctx is the ctx argument value.
@@ -272,6 +287,7 @@ type ZebedeeClientMock struct {
 	lockGetFileSize               sync.RWMutex
 	lockGetPageData               sync.RWMutex
 	lockGetResourceStream         sync.RWMutex
+	lockPublishCollection         sync.RWMutex
 	lockSaveContentToCollection   sync.RWMutex
 }
 
@@ -812,6 +828,46 @@ func (mock *ZebedeeClientMock) GetResourceStreamCalls() []struct {
 	mock.lockGetResourceStream.RLock()
 	calls = mock.calls.GetResourceStream
 	mock.lockGetResourceStream.RUnlock()
+	return calls
+}
+
+// PublishCollection calls PublishCollectionFunc.
+func (mock *ZebedeeClientMock) PublishCollection(ctx context.Context, authToken string, collectionID string) error {
+	if mock.PublishCollectionFunc == nil {
+		panic("ZebedeeClientMock.PublishCollectionFunc: method is nil but ZebedeeClient.PublishCollection was just called")
+	}
+	callInfo := struct {
+		Ctx          context.Context
+		AuthToken    string
+		CollectionID string
+	}{
+		Ctx:          ctx,
+		AuthToken:    authToken,
+		CollectionID: collectionID,
+	}
+	mock.lockPublishCollection.Lock()
+	mock.calls.PublishCollection = append(mock.calls.PublishCollection, callInfo)
+	mock.lockPublishCollection.Unlock()
+	return mock.PublishCollectionFunc(ctx, authToken, collectionID)
+}
+
+// PublishCollectionCalls gets all the calls that were made to PublishCollection.
+// Check the length with:
+//
+//	len(mockedZebedeeClient.PublishCollectionCalls())
+func (mock *ZebedeeClientMock) PublishCollectionCalls() []struct {
+	Ctx          context.Context
+	AuthToken    string
+	CollectionID string
+} {
+	var calls []struct {
+		Ctx          context.Context
+		AuthToken    string
+		CollectionID string
+	}
+	mock.lockPublishCollection.RLock()
+	calls = mock.calls.PublishCollection
+	mock.lockPublishCollection.RUnlock()
 	return calls
 }
 

--- a/executor/job_static_dataset.go
+++ b/executor/job_static_dataset.go
@@ -133,6 +133,66 @@ func (e *StaticDatasetJobExecutor) Publish(ctx context.Context, job *domain.Job)
 // PostPublish handles the post-publish operations for a static dataset job.
 func (e *StaticDatasetJobExecutor) PostPublish(ctx context.Context, job *domain.Job) error {
 	// Implementation of post-publish for static dataset
+	logData := log.Data{"job_number": job.JobNumber}
+	log.Info(ctx, "starting post-publishing for job", logData)
+
+	// update task state to post-publishing
+	totalTasks, err := e.jobService.CountTasksByJobNumber(ctx, job.JobNumber)
+	if err != nil {
+		log.Error(ctx, "failed to count tasks", err, logData)
+		return err
+	}
+
+	publishedTasks, _, err := e.jobService.GetJobTasks(ctx, []domain.State{domain.StatePublished}, job.JobNumber, totalTasks, 0)
+	if err != nil {
+		log.Error(ctx, "failed to get job tasks", err, logData)
+		return err
+	}
+	log.Info(ctx, "successfully got all job tasks", logData)
+
+	for _, task := range publishedTasks {
+		err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StatePostPublishing)
+		if err != nil {
+			log.Error(ctx, "failed to update task state", err, logData)
+			return err
+		}
+	}
+	log.Info(ctx, "successfully updated all job tasks state to post-publishing", logData)
+
+	// publishing zebedee collection
+	log.Info(ctx, "starting zebedee collection publish for job", logData)
+	err = e.clientList.Zebedee.PublishCollection(ctx, e.serviceAuthToken, job.Config.CollectionID)
+	if err != nil {
+		log.Error(ctx, "failed to publish collection in zebedee", err, logData)
+		return err
+	}
+
+	// update task state to completed
+
+	postPublishingTasks, _, err := e.jobService.GetJobTasks(ctx, []domain.State{domain.StatePostPublishing}, job.JobNumber, totalTasks, 0)
+	if err != nil {
+		log.Error(ctx, "failed to get job tasks", err, logData)
+		return err
+	}
+	log.Info(ctx, "successfully got all job tasks", logData)
+
+	for _, task := range postPublishingTasks {
+		err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StateCompleted)
+		if err != nil {
+			log.Error(ctx, "failed to update task state", err, logData)
+			return err
+		}
+	}
+	log.Info(ctx, "successfully updated all job tasks state to completed", logData)
+
+	// update job state to completed
+	err = e.jobService.UpdateJobState(ctx, job.JobNumber, domain.StateCompleted, "")
+	if err != nil {
+		log.Error(ctx, "failed to update job state to completed", err, logData)
+		return err
+	}
+	log.Info(ctx, "successfully updated job state to completed", logData)
+
 	return nil
 }
 

--- a/executor/job_static_dataset_test.go
+++ b/executor/job_static_dataset_test.go
@@ -44,17 +44,23 @@ func TestJobStaticDataset(t *testing.T) {
 			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error {
 				return nil
 			},
+			UpdateJobStateFunc: func(ctx context.Context, jobNumber int, state domain.State, userID string) error {
+				return nil
+			},
 		}
 		mockZebedeeClient := &clientMocks.ZebedeeClientMock{
+			ApproveCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
+				return nil
+			},
 			CreateCollectionFunc: func(ctx context.Context, userAuthToken string, collection zebedee.Collection) (zebedee.Collection, error) {
 				collection.ID = testCollectionID
 				return collection, nil
 			},
-			ApproveCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
-				return nil
-			},
 			GetCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) (zebedee.Collection, error) {
 				return zebedee.Collection{ApprovalStatus: zebedee.CollectionStatusComplete}, nil
+			},
+			PublishCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
+				return nil
 			},
 		}
 		mockClientList := &clients.ClientList{
@@ -121,6 +127,45 @@ func TestJobStaticDataset(t *testing.T) {
 						So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StateApproved)
 						So(mockJobService.UpdateTaskStateCalls()[1].TaskID, ShouldEqual, "task-2")
 						So(mockJobService.UpdateTaskStateCalls()[1].NewState, ShouldEqual, domain.StateApproved)
+					})
+				})
+			})
+		})
+
+		Convey("When post-publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePostPublishing,
+				Config: &domain.JobConfig{
+					CollectionID: testCollectionID,
+				},
+			}
+
+			err := executor.PostPublish(ctx, job)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+
+				Convey("And the zebedee collection is published", func() {
+					So(mockZebedeeClient.PublishCollectionCalls(), ShouldHaveLength, 1)
+					So(mockZebedeeClient.PublishCollectionCalls()[0].CollectionID, ShouldEqual, testCollectionID)
+
+					Convey("And all tasks are updated to post-publishing then completed", func() {
+						So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 4)
+						So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, "task-1")
+						So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StatePostPublishing)
+						So(mockJobService.UpdateTaskStateCalls()[1].TaskID, ShouldEqual, "task-2")
+						So(mockJobService.UpdateTaskStateCalls()[1].NewState, ShouldEqual, domain.StatePostPublishing)
+						So(mockJobService.UpdateTaskStateCalls()[2].TaskID, ShouldEqual, "task-1")
+						So(mockJobService.UpdateTaskStateCalls()[2].NewState, ShouldEqual, domain.StateCompleted)
+						So(mockJobService.UpdateTaskStateCalls()[3].TaskID, ShouldEqual, "task-2")
+						So(mockJobService.UpdateTaskStateCalls()[3].NewState, ShouldEqual, domain.StateCompleted)
+
+						Convey("And the job state is updated to completed", func() {
+							So(mockJobService.UpdateJobStateCalls(), ShouldHaveLength, 1)
+							So(mockJobService.UpdateJobStateCalls()[0].JobNumber, ShouldEqual, testJobNumber)
+							So(mockJobService.UpdateJobStateCalls()[0].NewState, ShouldEqual, domain.StateCompleted)
+						})
 					})
 				})
 			})
@@ -347,6 +392,9 @@ func TestJobStaticDataset(t *testing.T) {
 				GetCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) (zebedee.Collection, error) {
 					return zebedee.Collection{ApprovalStatus: zebedee.CollectionStatusComplete}, nil
 				},
+				PublishCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
+					return nil
+				},
 			},
 		}
 
@@ -363,6 +411,23 @@ func TestJobStaticDataset(t *testing.T) {
 			}
 
 			err := executor.Publish(ctx, job)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+				So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 0)
+			})
+		})
+
+		Convey("When post-publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePostPublishing,
+				Config: &domain.JobConfig{
+					CollectionID: testCollectionID,
+				},
+			}
+
+			err := executor.PostPublish(ctx, job)
 
 			Convey("Then an error is returned", func() {
 				So(err, ShouldEqual, errTest)
@@ -394,6 +459,9 @@ func TestJobStaticDataset(t *testing.T) {
 				GetCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) (zebedee.Collection, error) {
 					return zebedee.Collection{ApprovalStatus: zebedee.CollectionStatusComplete}, nil
 				},
+				PublishCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
+					return nil
+				},
 			},
 		}
 
@@ -416,6 +484,23 @@ func TestJobStaticDataset(t *testing.T) {
 				So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 1)
 			})
 		})
+
+		Convey("When post-publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePostPublishing,
+				Config: &domain.JobConfig{
+					CollectionID: testCollectionID,
+				},
+			}
+
+			err := executor.PostPublish(ctx, job)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+				So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 1)
+			})
+		})
 	})
 
 	Convey("Given a static dataset job executor and a job service that errors when counting tasks", t, func() {
@@ -431,6 +516,9 @@ func TestJobStaticDataset(t *testing.T) {
 				},
 				GetCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) (zebedee.Collection, error) {
 					return zebedee.Collection{ApprovalStatus: zebedee.CollectionStatusComplete}, nil
+				},
+				PublishCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
+					return nil
 				},
 			},
 		}
@@ -452,6 +540,115 @@ func TestJobStaticDataset(t *testing.T) {
 			Convey("Then an error is returned", func() {
 				So(err, ShouldEqual, errTest)
 				So(mockJobService.GetJobTasksCalls(), ShouldHaveLength, 0)
+			})
+		})
+
+		Convey("When post-publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePostPublishing,
+				Config: &domain.JobConfig{
+					CollectionID: testCollectionID,
+				},
+			}
+
+			err := executor.PostPublish(ctx, job)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+				So(mockJobService.GetJobTasksCalls(), ShouldHaveLength, 0)
+			})
+		})
+	})
+
+	Convey("Given a static dataset job executor and a zebedee client that errors when publishing the collection", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			CountTasksByJobNumberFunc: func(ctx context.Context, jobNumber int) (int, error) {
+				return 2, nil
+			},
+			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber, limit, offset int) ([]*domain.Task, int, error) {
+				return []*domain.Task{
+					{ID: "task-1", State: domain.StatePublished},
+					{ID: "task-2", State: domain.StatePublished},
+				}, 2, nil
+			},
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error {
+				return nil
+			},
+		}
+		mockZebedeeClient := &clientMocks.ZebedeeClientMock{
+			PublishCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
+				return errTest
+			},
+		}
+		mockClientList := &clients.ClientList{
+			Zebedee: mockZebedeeClient,
+		}
+
+		ctx := context.Background()
+		executor := NewStaticDatasetJobExecutor(mockJobService, mockClientList, "faketoken")
+
+		Convey("When post-publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePostPublishing,
+				Config: &domain.JobConfig{
+					CollectionID: testCollectionID,
+				},
+			}
+
+			err := executor.PostPublish(ctx, job)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+			})
+		})
+	})
+
+	Convey("Given a static dataset job executor and a job service that errors when updating job state", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			CountTasksByJobNumberFunc: func(ctx context.Context, jobNumber int) (int, error) {
+				return 2, nil
+			},
+			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber, limit, offset int) ([]*domain.Task, int, error) {
+				return []*domain.Task{
+					{ID: "task-1", State: domain.StatePublished},
+					{ID: "task-2", State: domain.StatePublished},
+				}, 2, nil
+			},
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error {
+				return nil
+			},
+			UpdateJobStateFunc: func(ctx context.Context, jobNumber int, state domain.State, userID string) error {
+				return errTest
+			},
+		}
+		mockClientList := &clients.ClientList{
+			Zebedee: &clientMocks.ZebedeeClientMock{
+				PublishCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
+					return nil
+				},
+			},
+		}
+
+		ctx := context.Background()
+		executor := NewStaticDatasetJobExecutor(mockJobService, mockClientList, "faketoken")
+
+		Convey("When post-publish is called for a job", func() {
+			job := &domain.Job{
+				JobNumber: testJobNumber,
+				State:     domain.StatePostPublishing,
+				Config: &domain.JobConfig{
+					CollectionID: testCollectionID,
+				},
+			}
+
+			err := executor.PostPublish(ctx, job)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+				So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 4)
+				So(mockJobService.UpdateJobStateCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})

--- a/features/get_jobs.feature
+++ b/features/get_jobs.feature
@@ -267,11 +267,11 @@ Feature: Get list of jobs
       And the following document exists in the "jobs" collection:
         """
         {
-          "_id": "job-published-1",
+          "_id": "job-completed-1",
           "job_number": 24,
-          "label": "job-published-1",
+          "label": "job-completed-1",
           "last_updated": "2025-11-19T14:00:00Z",
-          "state": "published",
+          "state": "completed",
           "config": {
             "source_id": "s2",
             "target_id": "t2",
@@ -279,17 +279,17 @@ Feature: Get list of jobs
           }
         }
         """
-      When I GET "/v1/migration-jobs?state=published"
+      When I GET "/v1/migration-jobs?state=completed"
       Then I should receive the following JSON response with status "200":
         """
         {
           "count": 1,
           "items": [
             {
-              "id": "job-published-1",
+              "id": "job-completed-1",
               "job_number": 24,
-              "label": "job-published-1",
-              "state": "published",
+              "label": "job-completed-1",
+              "state": "completed",
               "config": {
                 "source_id": "s2",
                 "target_id": "t2",
@@ -300,14 +300,14 @@ Feature: Get list of jobs
             }
           ],
           "states": [
-            {
-              "id": "migrating",
-              "label": "Migrating",
+          {
+              "id": "completed",
+              "label": "Completed",
               "count": 1
             },
             {
-              "id": "published",
-              "label": "Published",
+              "id": "migrating",
+              "label": "Migrating",
               "count": 1
             }
           ],

--- a/features/publish_static_dataset.feature
+++ b/features/publish_static_dataset.feature
@@ -70,6 +70,7 @@ Feature: Publish a static dataset job
       }
       """
     Then the HTTP status code should be "204"
+    # Post-publish runs automatically once job reaches published state
     And I wait 2 seconds for the job processor to process tasks and jobs
     When I GET "/v1/migration-jobs/30"
     Then I should receive the following JSON response with status "200":
@@ -77,7 +78,7 @@ Feature: Publish a static dataset job
       {
         "id": "3985ff0f-2d46-51gg-022g-6b33f8173802",
         "job_number": 30,
-        "state": "published",
+        "state": "completed",
         "last_updated": "{{DYNAMIC_TIMESTAMP}}",
         "config": {
           "collection_id": "migration-job-test-collection",
@@ -102,7 +103,7 @@ Feature: Publish a static dataset job
             "id": "task-223e4567-e89b-12d3-a456-426614174000",
             "job_number": 30,
             "type": "dataset_series",
-            "state": "published",
+            "state": "completed",
             "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
             "links": {
               "self": {

--- a/features/steps/fakeapi.go
+++ b/features/steps/fakeapi.go
@@ -28,6 +28,7 @@ type FakeAPI struct {
 	collectionGetHandler             *httpfake.Request
 	collectionApproveHandler         *httpfake.Request
 	collectionDetailsHandler         *httpfake.Request
+	collectionPublishHandler         *httpfake.Request
 }
 
 // NewFakeAPI creates a new fake component API
@@ -69,6 +70,9 @@ func NewFakeAPI() *FakeAPI {
 		ApprovalStatus: "COMPLETE",
 	})
 
+	collectionPublishHandler := fakeAPI.NewHandler().Post(fmt.Sprintf("/publish/%s", testCollectionID))
+	collectionPublishHandler.Reply(200)
+
 	return &FakeAPI{
 		fakeHTTP:                         fakeAPI,
 		datasetCreateHandler:             fakeAPI.NewHandler().Post("/datasets"),
@@ -79,6 +83,7 @@ func NewFakeAPI() *FakeAPI {
 		collectionGetHandler:             collectionGetHandler,
 		collectionApproveHandler:         collectionApproveHandler,
 		collectionDetailsHandler:         collectionDetailsHandler,
+		collectionPublishHandler:         collectionPublishHandler,
 	}
 }
 

--- a/migrator/jobs.go
+++ b/migrator/jobs.go
@@ -111,6 +111,8 @@ func (mig *migrator) executeJob(ctx context.Context, job *domain.Job) {
 			err = jobExecutor.Migrate(ctx, job)
 		case domain.StatePublishing:
 			err = jobExecutor.Publish(ctx, job)
+		case domain.StatePostPublishing:
+			err = jobExecutor.PostPublish(ctx, job)
 		case domain.StateReverting:
 			err = jobExecutor.Revert(ctx, job)
 		default:

--- a/migrator/jobs_test.go
+++ b/migrator/jobs_test.go
@@ -50,6 +50,9 @@ func TestMigratorExecuteJob(t *testing.T) {
 			PublishFunc: func(ctx context.Context, job *domain.Job) error {
 				return nil
 			},
+			PostPublishFunc: func(ctx context.Context, job *domain.Job) error {
+				return nil
+			},
 			RevertFunc: func(ctx context.Context, job *domain.Job) error {
 				return nil
 			},
@@ -167,6 +170,24 @@ func TestMigratorExecuteJob(t *testing.T) {
 			Convey("Then the executor is called to publish", func() {
 				So(len(mockJobExecutor.PublishCalls()), ShouldEqual, 1)
 				So(mockJobExecutor.PublishCalls()[0].Job.JobNumber, ShouldEqual, fakeJobNumber)
+			})
+		})
+
+		Convey("When a job in state post-publishing is executed", func() {
+			job := &domain.Job{
+				JobNumber: fakeJobNumber,
+				Config: &domain.JobConfig{
+					Type: fakeJobType,
+				},
+				State: domain.StatePostPublishing,
+			}
+
+			mig.executeJob(context.Background(), job)
+			mig.wg.Wait()
+
+			Convey("Then the executor is called to post-publish", func() {
+				So(len(mockJobExecutor.PostPublishCalls()), ShouldEqual, 1)
+				So(mockJobExecutor.PostPublishCalls()[0].Job.JobNumber, ShouldEqual, fakeJobNumber)
 			})
 		})
 	})
@@ -314,6 +335,62 @@ func TestMigratorExecuteJob(t *testing.T) {
 			Convey("Then the job is failed", func() {
 				So(len(mockJobService.UpdateJobStateCalls()), ShouldEqual, 1)
 				So(mockJobService.UpdateJobStateCalls()[0].NewState, ShouldEqual, domain.StateFailedPublish)
+			})
+		})
+	})
+
+	Convey("Given a migrator with an executor that fails to complete the job", t, func() {
+		mockJobExecutor := &executorMocks.JobExecutorMock{
+			MigrateFunc: func(ctx context.Context, job *domain.Job) error {
+				return nil
+			},
+			PublishFunc: func(ctx context.Context, job *domain.Job) error {
+				return nil
+			},
+			PostPublishFunc: func(ctx context.Context, job *domain.Job) error {
+				return errors.New("post-publish error")
+			},
+		}
+
+		getJobExecutors = func(_ application.JobService, _ *clients.ClientList, _ *config.Config) map[domain.JobType]executor.JobExecutor {
+			return map[domain.JobType]executor.JobExecutor{
+				fakeJobType: mockJobExecutor,
+			}
+		}
+
+		mockJobService := &applicationMocks.JobServiceMock{
+			UpdateJobStateFunc: func(ctx context.Context, jobNumber int, state domain.State, userID string) error {
+				return nil
+			},
+			GetNextJobNumberFunc: func(ctx context.Context) (*domain.Counter, error) {
+				fakeCounter := domain.Counter{}
+				return &fakeCounter, nil
+			},
+		}
+
+		mockClients := &clients.ClientList{}
+		mockSlackClient := createMockSlackClient()
+		cfg := &config.Config{
+			MigratorMaxConcurrentExecutions: 1,
+		}
+
+		topicCache, _ := cache.NewPopulatedTopicCacheForTest(context.Background())
+		mig, _ := NewDefaultMigrator(cfg, mockJobService, mockClients, mockSlackClient, topicCache)
+
+		Convey("When a job is executed that errors during post-publishing", func() {
+			job := &domain.Job{
+				JobNumber: fakeJobNumber,
+				State:     domain.StatePostPublishing,
+				Config: &domain.JobConfig{
+					Type: fakeJobType,
+				},
+			}
+			mig.executeJob(context.Background(), job)
+			mig.wg.Wait()
+
+			Convey("Then the job is failed", func() {
+				So(len(mockJobService.UpdateJobStateCalls()), ShouldEqual, 1)
+				So(mockJobService.UpdateJobStateCalls()[0].NewState, ShouldEqual, domain.StateFailedPostPublish)
 			})
 		})
 	})

--- a/migrator/state_transition_rule.go
+++ b/migrator/state_transition_rule.go
@@ -36,6 +36,11 @@ func (mig *migrator) GetStateTransitionRules() map[domain.State]StateTransitionR
 			FailureState: domain.StateFailedPublish,
 			Description:  "publish successful, move to published",
 		},
+		domain.StatePostPublishing: {
+			TargetState:  domain.StateCompleted,
+			FailureState: domain.StateFailedPostPublish,
+			Description:  "post-publish successful, move to completed",
+		},
 		domain.StateReverting: {
 			TargetState:  domain.StateCancelled,
 			FailureState: domain.StateFailedReversion,


### PR DESCRIPTION
### What

[add post publish functionality for a migrated dataset](https://officefornationalstatistics.atlassian.net/browse/DIS-3968?atlOrigin=eyJpIjoiMWZlYTBjN2VjOWFkNDgwOWExY2M1NGYyNzkzY2FiNzgiLCJwIjoiaiJ9)

- zebedee collection -> published
- job state -> completed
- task states -> completed

### How to review

sense check

**Optionally**
- Pull this branch
- Run the migration stack
- Post the demo job
- make a PUT request to update the job's state once it's `in_review`:

`http://localhost:30100/v1/migration-jobs/1/state`
with the body being:
`{
    "state": "approved"
}`

- GET the job, and it's state should now be `completed`
- GET the tasks `http://localhost:30100/v1/migration-jobs/1/tasks` and they should now be `completed`
- Check the collection on disk (dp-zebedee-content/generated/publishing/zebedee/collections), and it should now show:
`"publishComplete": true,`

### Who can review

not me