### PR TITLE
Feature/state summary data for get jobs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -37,7 +37,7 @@ func Setup(_ context.Context, cfg *config.Config, router *mux.Router, jobService
 	}
 
 	api.get("/v1/migration-jobs",
-		authMiddleware.Require("migrations:read", paginator.Paginate(api.getJobs)),
+		authMiddleware.Require("migrations:read", api.getJobs),
 	)
 
 	api.post(

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -22,6 +22,14 @@ type StateChangeRequest struct {
 	State domain.State `json:"state"`
 }
 
+// JobsListResponse represents the response structure for a paginated list of
+// jobs.
+type JobsListResponse struct {
+	Items  []*domain.Job         `json:"items"`
+	States []domain.StateSummary `json:"states"`
+	PaginationFields
+}
+
 // getJob is an implementation for retrieving a migration job.
 func (api *MigrationAPI) getJob(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -54,7 +62,15 @@ func (api *MigrationAPI) getJob(w http.ResponseWriter, r *http.Request) {
 }
 
 // getJobs is an implementation of PaginatedHandler for retrieving jobs.
-func (api *MigrationAPI) getJobs(w http.ResponseWriter, r *http.Request, limit, offset int) (items interface{}, totalCount int, err error) {
+func (api *MigrationAPI) getJobs(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	limit, offset, errs := api.Paginator.getPaginationParameters(r)
+	if len(errs) > 0 {
+		handleError(ctx, w, r, errs...)
+		return
+	}
+
 	statesParam := r.URL.Query()["state"] // supports ?state=a&state=b and ?state=a,b
 	states := make([]domain.State, 0, len(statesParam))
 
@@ -62,7 +78,8 @@ func (api *MigrationAPI) getJobs(w http.ResponseWriter, r *http.Request, limit, 
 		for _, p := range strings.Split(s, ",") {
 			state := domain.State(strings.TrimSpace(p))
 			if !domain.IsValidState(state) {
-				return nil, 0, appErrors.ErrJobStateInvalid
+				handleError(ctx, w, r, appErrors.ErrJobStateInvalid)
+				return
 			}
 			states = append(states, state)
 		}
@@ -71,10 +88,44 @@ func (api *MigrationAPI) getJobs(w http.ResponseWriter, r *http.Request, limit, 
 	sortParam := r.URL.Query()[QueryParameterSort]
 	field, direction, err := sort.ParseSortParameters(sortParam)
 	if err != nil {
-		return nil, 0, err
+		handleError(ctx, w, r, err)
+		return
 	}
 
-	return api.JobService.GetJobs(r.Context(), field, direction, states, limit, offset)
+	jobs, totalCount, err := api.JobService.GetJobs(ctx, field, direction, states, limit, offset)
+	if err != nil {
+		handleError(ctx, w, r, err)
+		return
+	}
+
+	if len(jobs) == 0 {
+		jobs = []*domain.Job{}
+	}
+
+	stateSummaries, err := api.JobService.GetJobStatesSummary(ctx)
+	if err != nil {
+		handleError(ctx, w, r, err)
+		return
+	}
+
+	jobsListResponse := JobsListResponse{
+		Items:  jobs,
+		States: stateSummaries,
+		PaginationFields: PaginationFields{
+			Count:      len(jobs),
+			Limit:      limit,
+			Offset:     offset,
+			TotalCount: totalCount,
+		},
+	}
+
+	responseBytes, err := json.Marshal(jobsListResponse)
+	if err != nil {
+		handleError(ctx, w, r, err)
+		return
+	}
+
+	handleSuccess(ctx, w, r, http.StatusOK, responseBytes)
 }
 
 // getJobTasks is an implementation of PaginatedHandler for retrieving
@@ -89,9 +140,8 @@ func (api *MigrationAPI) getJobTasks(w http.ResponseWriter, r *http.Request, lim
 	}
 	jobNumber, err := strconv.Atoi(jobNumberStr)
 	if err != nil {
-		log.Error(ctx, "failed to get job -  job number must be an int", err)
-		handleError(ctx, w, r, err)
-		return &[]domain.Task{}, 0, err
+		log.Info(ctx, "failed to get job - job number must be an int")
+		return nil, 0, appErrors.ErrJobNumberMustBeInt
 	}
 
 	// Ensure job exists -> return 404 if not found
@@ -191,9 +241,8 @@ func (api *MigrationAPI) getJobEvents(w http.ResponseWriter, r *http.Request, li
 
 	jobNumber, err := strconv.Atoi(jobNumberStr)
 	if err != nil {
-		log.Error(ctx, "failed to get job -  job number must be an int", err)
-		handleError(ctx, w, r, err)
-		return
+		log.Info(ctx, "failed to get job - job number must be an int")
+		return nil, 0, appErrors.ErrJobNumberMustBeInt
 	}
 
 	// Ensure job exists -> return 404 if not found
@@ -240,7 +289,7 @@ func (api *MigrationAPI) updateJobState(
 
 	jobNumber, err := strconv.Atoi(jobNumberStr)
 	if err != nil {
-		log.Info(ctx, "failed to get job -  job number must be an int", logData)
+		log.Info(ctx, "failed to get job - job number must be an int", logData)
 		handleError(ctx, w, r, appErrors.ErrJobNumberMustBeInt)
 		return
 	}

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -339,7 +339,7 @@ func TestGetJobs(t *testing.T) {
 			resp := httptest.NewRecorder()
 			api.Router.ServeHTTP(resp, req)
 
-			Convey("Then only jobs matching that state are returned and the state summary includes all states", func() {
+			Convey("Then only jobs matching that state are returned and the state summary includes all stored states", func() {
 				So(resp.Code, ShouldEqual, http.StatusOK)
 
 				bodyBytes, err := io.ReadAll(resp.Body)

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -73,6 +73,18 @@ func TestGetJob(t *testing.T) {
 				So(resp.Body.String(), ShouldContainSubstring, strconv.Itoa(testJobNumber))
 			})
 		})
+
+		Convey("When an invalid request is made with a non-integer job number", func() {
+			req := httptest.NewRequest(http.MethodGet, "http://localhost:30100/v1/migration-jobs/invalid", http.NoBody)
+			resp := httptest.NewRecorder()
+
+			api.Router.ServeHTTP(resp, req)
+
+			Convey("Then a 400 Bad Request is returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusBadRequest)
+				So(resp.Body.String(), ShouldContainSubstring, appErrors.ErrJobNumberMustBeInt.Error())
+			})
+		})
 	})
 
 	Convey("Given a test API instance and a mocked jobservice that returns not found", t, func() {
@@ -131,14 +143,14 @@ func TestGetJob(t *testing.T) {
 		api := Setup(ctx, cfg, r, &mockService, mockAuthMiddleware)
 
 		Convey("When a request is made and the service errors", func() {
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:30100/v1/migration-jobs/%s", testID), http.NoBody)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:30100/v1/migration-jobs/%d", testJobNumber), http.NoBody)
 			resp := httptest.NewRecorder()
 
 			api.Router.ServeHTTP(resp, req)
 
 			Convey("Then a 500 is returned", func() {
-				So(resp.Code, ShouldEqual, http.StatusBadRequest)
-				// you can assert on the body if your handleError writes a specific message
+				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+				So(resp.Body.String(), ShouldContainSubstring, appErrors.ErrInternalServerError.Error())
 			})
 		})
 	})
@@ -146,14 +158,29 @@ func TestGetJob(t *testing.T) {
 
 func TestGetJobs(t *testing.T) {
 	Convey("Given a test API instance and a mocked jobservice that returns multiple jobs", t, func() {
+		testSubmittedJob := &domain.Job{ID: "job1", State: domain.StateSubmitted}
+		testApprovedJob := &domain.Job{ID: "job2", State: domain.StateApproved}
+		testCompletedJob := &domain.Job{ID: "job3", State: domain.StateCompleted}
+
+		testJobs := []*domain.Job{
+			testSubmittedJob,
+			testApprovedJob,
+			testCompletedJob,
+		}
+
+		testSummaries := []domain.StateSummary{
+			{ID: domain.StateApproved, Label: "Approved", Count: 1},
+			{ID: domain.StateCompleted, Label: "Completed", Count: 1},
+			{ID: domain.StateSubmitted, Label: "Submitted", Count: 1},
+		}
+
 		mockService := applicationMock.JobServiceMock{
 			GetJobsFunc: func(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
-				jobs := []*domain.Job{
-					{ID: "job1", State: domain.StateSubmitted},
-					{ID: "job2", State: domain.StateApproved},
-					{ID: "job3", State: domain.StateCompleted},
-				}
+				jobs := testJobs
 				return jobs, len(jobs), nil
+			},
+			GetJobStatesSummaryFunc: func(ctx context.Context) ([]domain.StateSummary, error) {
+				return testSummaries, nil
 			},
 		}
 
@@ -176,23 +203,32 @@ func TestGetJobs(t *testing.T) {
 			resp := httptest.NewRecorder()
 			api.Router.ServeHTTP(resp, req)
 
-			Convey("Then multiple jobs are returned", func() {
+			Convey("Then multiple jobs and state summaries are returned", func() {
 				So(resp.Code, ShouldEqual, http.StatusOK)
 
 				bodyBytes, err := io.ReadAll(resp.Body)
 				So(err, ShouldBeNil)
 
-				var paginatedResponse struct {
-					Items []domain.Job `json:"items"`
-				}
-
-				err = json.Unmarshal(bodyBytes, &paginatedResponse)
+				var jobsResponse JobsListResponse
+				err = json.Unmarshal(bodyBytes, &jobsResponse)
 				So(err, ShouldBeNil)
-				So(len(paginatedResponse.Items), ShouldEqual, 3)
 
-				Convey("And the service is called with all states", func() {
+				expectedResponse := JobsListResponse{
+					Items:  testJobs,
+					States: testSummaries,
+					PaginationFields: PaginationFields{
+						Count:      len(testJobs),
+						Limit:      cfg.DefaultLimit,
+						Offset:     0,
+						TotalCount: len(testJobs),
+					},
+				}
+				So(jobsResponse, ShouldResemble, expectedResponse)
+
+				Convey("And both service methods are called", func() {
 					So(len(mockService.GetJobsCalls()), ShouldEqual, 1)
 					So(mockService.GetJobsCalls()[0].States, ShouldResemble, []domain.State{})
+					So(len(mockService.GetJobStatesSummaryCalls()), ShouldEqual, 1)
 				})
 			})
 		})
@@ -243,46 +279,121 @@ func TestGetJobs(t *testing.T) {
 		})
 
 		Convey("When a request is made with a single valid state", func() {
+			mockService.GetJobsFunc = func(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
+				jobs := []*domain.Job{testSubmittedJob}
+				return jobs, len(testJobs), nil
+			}
+
 			req := httptest.NewRequest(http.MethodGet, "http://localhost:30100/v1/migration-jobs?state=submitted", http.NoBody)
 			resp := httptest.NewRecorder()
 			api.Router.ServeHTTP(resp, req)
 
-			Convey("Then only jobs matching that state are returned", func() {
+			Convey("Then only jobs matching that state are returned and the state summary includes all states", func() {
 				So(resp.Code, ShouldEqual, http.StatusOK)
+
+				bodyBytes, err := io.ReadAll(resp.Body)
+				So(err, ShouldBeNil)
+
+				var jobsResponse JobsListResponse
+				err = json.Unmarshal(bodyBytes, &jobsResponse)
+				So(err, ShouldBeNil)
+
+				expectedResponse := JobsListResponse{
+					Items:  []*domain.Job{testSubmittedJob},
+					States: testSummaries,
+					PaginationFields: PaginationFields{
+						Count:      1,
+						Limit:      cfg.DefaultLimit,
+						Offset:     0,
+						TotalCount: len(testJobs),
+					},
+				}
+				So(jobsResponse, ShouldResemble, expectedResponse)
 
 				Convey("And the service is called with the submitted state", func() {
 					So(len(mockService.GetJobsCalls()), ShouldEqual, 1)
 					So(mockService.GetJobsCalls()[0].States, ShouldResemble, []domain.State{domain.StateSubmitted})
+					So(len(mockService.GetJobStatesSummaryCalls()), ShouldEqual, 1)
 				})
 			})
 		})
 
 		Convey("When a request is made with multiple valid states, using repeated query param", func() {
+			mockService.GetJobsFunc = func(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
+				jobs := []*domain.Job{testSubmittedJob, testApprovedJob}
+				return jobs, len(testJobs), nil
+			}
+
 			req := httptest.NewRequest(http.MethodGet, "http://localhost:30100/v1/migration-jobs?state=submitted&state=approved", http.NoBody)
 			resp := httptest.NewRecorder()
 			api.Router.ServeHTTP(resp, req)
 
-			Convey("Then jobs matching any of the states are returned", func() {
+			Convey("Then jobs matching any of the states are returned and the state summary includes all states", func() {
 				So(resp.Code, ShouldEqual, http.StatusOK)
+
+				bodyBytes, err := io.ReadAll(resp.Body)
+				So(err, ShouldBeNil)
+
+				var jobsResponse JobsListResponse
+				err = json.Unmarshal(bodyBytes, &jobsResponse)
+				So(err, ShouldBeNil)
+
+				expectedResponse := JobsListResponse{
+					Items:  []*domain.Job{testSubmittedJob, testApprovedJob},
+					States: testSummaries,
+					PaginationFields: PaginationFields{
+						Count:      2,
+						Limit:      cfg.DefaultLimit,
+						Offset:     0,
+						TotalCount: len(testJobs),
+					},
+				}
+				So(jobsResponse, ShouldResemble, expectedResponse)
 
 				Convey("And the service is called with both states", func() {
 					So(len(mockService.GetJobsCalls()), ShouldEqual, 1)
 					So(mockService.GetJobsCalls()[0].States, ShouldResemble, []domain.State{domain.StateSubmitted, domain.StateApproved})
+					So(len(mockService.GetJobStatesSummaryCalls()), ShouldEqual, 1)
 				})
 			})
 		})
 
 		Convey("When a request is made with multiple valid states, using comma-separated values", func() {
+			mockService.GetJobsFunc = func(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
+				jobs := []*domain.Job{testSubmittedJob, testApprovedJob}
+				return jobs, len(testJobs), nil
+			}
+
 			req := httptest.NewRequest(http.MethodGet, "http://localhost:30100/v1/migration-jobs?state=submitted,approved", http.NoBody)
 			resp := httptest.NewRecorder()
 			api.Router.ServeHTTP(resp, req)
 
-			Convey("Then jobs matching any of the states are returned", func() {
+			Convey("Then jobs matching any of the states are returned and the state summary includes all states", func() {
 				So(resp.Code, ShouldEqual, http.StatusOK)
+
+				bodyBytes, err := io.ReadAll(resp.Body)
+				So(err, ShouldBeNil)
+
+				var jobsResponse JobsListResponse
+				err = json.Unmarshal(bodyBytes, &jobsResponse)
+				So(err, ShouldBeNil)
+
+				expectedResponse := JobsListResponse{
+					Items:  []*domain.Job{testSubmittedJob, testApprovedJob},
+					States: testSummaries,
+					PaginationFields: PaginationFields{
+						Count:      2,
+						Limit:      cfg.DefaultLimit,
+						Offset:     0,
+						TotalCount: len(testJobs),
+					},
+				}
+				So(jobsResponse, ShouldResemble, expectedResponse)
 
 				Convey("And the service is called with both states", func() {
 					So(len(mockService.GetJobsCalls()), ShouldEqual, 1)
 					So(mockService.GetJobsCalls()[0].States, ShouldResemble, []domain.State{domain.StateSubmitted, domain.StateApproved})
+					So(len(mockService.GetJobStatesSummaryCalls()), ShouldEqual, 1)
 				})
 			})
 		})
@@ -303,6 +414,9 @@ func TestGetJobs(t *testing.T) {
 		})
 
 		Convey("When a request is made with valid sort parameters", func() {
+			mockService.GetJobsFunc = func(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
+				return testJobs, len(testJobs), nil
+			}
 			req := httptest.NewRequest(http.MethodGet, "http://localhost:30100/v1/migration-jobs?sort=job_number:asc", http.NoBody)
 			resp := httptest.NewRecorder()
 			api.Router.ServeHTTP(resp, req)
@@ -310,10 +424,30 @@ func TestGetJobs(t *testing.T) {
 			Convey("Then the server should respond with status 200 OK", func() {
 				So(resp.Code, ShouldEqual, http.StatusOK)
 
+				bodyBytes, err := io.ReadAll(resp.Body)
+				So(err, ShouldBeNil)
+
+				var jobsResponse JobsListResponse
+				err = json.Unmarshal(bodyBytes, &jobsResponse)
+				So(err, ShouldBeNil)
+
+				expectedResponse := JobsListResponse{
+					Items:  testJobs,
+					States: testSummaries,
+					PaginationFields: PaginationFields{
+						Count:      len(testJobs),
+						Limit:      cfg.DefaultLimit,
+						Offset:     0,
+						TotalCount: len(testJobs),
+					},
+				}
+				So(jobsResponse, ShouldResemble, expectedResponse)
+
 				Convey("And the service is called with the correct field and direction", func() {
 					So(len(mockService.GetJobsCalls()), ShouldEqual, 1)
 					So(mockService.GetJobsCalls()[0].Field, ShouldResemble, sort.SortParameterFieldJobNumber)
 					So(mockService.GetJobsCalls()[0].Direction, ShouldResemble, sort.SortParameterDirectionAsc)
+					So(len(mockService.GetJobStatesSummaryCalls()), ShouldEqual, 1)
 				})
 			})
 		})
@@ -354,6 +488,9 @@ func TestGetJobs(t *testing.T) {
 			GetJobsFunc: func(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
 				return []*domain.Job{}, 0, nil
 			},
+			GetJobStatesSummaryFunc: func(ctx context.Context) ([]domain.StateSummary, error) {
+				return []domain.StateSummary{}, nil
+			},
 		}
 
 		mockAuthMiddleware := &authorisationMock.MiddlewareMock{
@@ -375,19 +512,102 @@ func TestGetJobs(t *testing.T) {
 			resp := httptest.NewRecorder()
 			api.Router.ServeHTTP(resp, req)
 
-			Convey("Then no jobs are returned", func() {
+			Convey("Then no jobs are returned and states is an empty array", func() {
 				So(resp.Code, ShouldEqual, http.StatusOK)
 
 				bodyBytes, err := io.ReadAll(resp.Body)
 				So(err, ShouldBeNil)
 
-				var paginatedResponse struct {
-					Items []domain.Job `json:"items"`
-				}
-
-				err = json.Unmarshal(bodyBytes, &paginatedResponse)
+				var jobsResponse JobsListResponse
+				err = json.Unmarshal(bodyBytes, &jobsResponse)
 				So(err, ShouldBeNil)
-				So(len(paginatedResponse.Items), ShouldEqual, 0)
+
+				expectedResponse := JobsListResponse{
+					Items:  []*domain.Job{},
+					States: []domain.StateSummary{},
+					PaginationFields: PaginationFields{
+						Count:      0,
+						Limit:      cfg.DefaultLimit,
+						Offset:     0,
+						TotalCount: 0,
+					},
+				}
+				So(jobsResponse, ShouldResemble, expectedResponse)
+
+				Convey("And both service methods are called", func() {
+					So(len(mockService.GetJobsCalls()), ShouldEqual, 1)
+					So(len(mockService.GetJobStatesSummaryCalls()), ShouldEqual, 1)
+				})
+			})
+		})
+	})
+
+	Convey("Given a test API instance and a mocked jobservice that returns an error when calling GetJobs", t, func() {
+		mockService := applicationMock.JobServiceMock{
+			GetJobsFunc: func(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
+				return nil, 0, errors.New("database failure")
+			},
+		}
+
+		mockAuthMiddleware := &authorisationMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			CloseFunc: func(ctx context.Context) error {
+				return nil
+			},
+		}
+
+		r := mux.NewRouter()
+		ctx := context.Background()
+		cfg := &config.Config{}
+		api := Setup(ctx, cfg, r, &mockService, mockAuthMiddleware)
+
+		Convey("When a valid request is made", func() {
+			req := httptest.NewRequest(http.MethodGet, "http://localhost:30100/v1/migration-jobs", http.NoBody)
+			resp := httptest.NewRecorder()
+			api.Router.ServeHTTP(resp, req)
+
+			Convey("Then a 500 Internal Server Error is returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+				So(resp.Body.String(), ShouldContainSubstring, appErrors.ErrInternalServerError.Error())
+			})
+		})
+	})
+
+	Convey("Given a test API instance and a mocked jobservice that returns an error when calling GetJobStatesSummary", t, func() {
+		mockService := applicationMock.JobServiceMock{
+			GetJobsFunc: func(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
+				jobs := []*domain.Job{{ID: "job1", State: domain.StateSubmitted}}
+				return jobs, len(jobs), nil
+			},
+			GetJobStatesSummaryFunc: func(ctx context.Context) ([]domain.StateSummary, error) {
+				return nil, errors.New("summary failure")
+			},
+		}
+
+		mockAuthMiddleware := &authorisationMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			CloseFunc: func(ctx context.Context) error {
+				return nil
+			},
+		}
+
+		r := mux.NewRouter()
+		ctx := context.Background()
+		cfg := &config.Config{}
+		api := Setup(ctx, cfg, r, &mockService, mockAuthMiddleware)
+
+		Convey("When a valid request is made", func() {
+			req := httptest.NewRequest(http.MethodGet, "http://localhost:30100/v1/migration-jobs", http.NoBody)
+			resp := httptest.NewRecorder()
+			api.Router.ServeHTTP(resp, req)
+
+			Convey("Then a 500 Internal Server Error is returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+				So(resp.Body.String(), ShouldContainSubstring, appErrors.ErrInternalServerError.Error())
 			})
 		})
 	})
@@ -569,6 +789,21 @@ func TestGetJobTasks(t *testing.T) {
 			So(total, ShouldEqual, 0)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, appErrors.ErrJobNumberNotProvided)
+		})
+
+		Convey("invalid non-integer job number should return ErrJobNumberMustBeInt", func() {
+			mockService := applicationMock.JobServiceMock{}
+			api := Setup(ctx, cfg, r, &mockService, mockAuthMiddleware)
+
+			req := httptest.NewRequest(http.MethodGet, "http://localhost:30100/v1/migration-jobs/invalid/tasks", http.NoBody)
+			req = mux.SetURLVars(req, map[string]string{PathParameterJobNumber: "invalid"})
+			rr := httptest.NewRecorder()
+
+			items, total, err := api.getJobTasks(rr, req, 10, 0)
+			So(items, ShouldBeNil)
+			So(total, ShouldEqual, 0)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldEqual, appErrors.ErrJobNumberMustBeInt)
 		})
 
 		Convey("job not found should return ErrJobNotFound", func() {
@@ -792,6 +1027,26 @@ func TestGetJobEvents(t *testing.T) {
 					So(items, ShouldBeNil)
 					So(total, ShouldEqual, 0)
 					So(err, ShouldEqual, appErrors.ErrJobNumberNotProvided)
+				})
+			})
+		})
+
+		Convey("And the job number is not an integer", func() {
+			mockService := &applicationMock.JobServiceMock{}
+			api := Setup(ctx, cfg, r, mockService, mockAuthMiddleware)
+
+			req := httptest.NewRequest(http.MethodGet,
+				"http://localhost:30100/v1/migration-jobs/invalid/events", http.NoBody)
+			req = mux.SetURLVars(req, map[string]string{PathParameterJobNumber: "invalid"})
+			rr := httptest.NewRecorder()
+
+			Convey("When getJobEvents is called", func() {
+				items, total, err := api.getJobEvents(rr, req, 10, 0)
+
+				Convey("Then it returns ErrJobNumberMustBeInt", func() {
+					So(items, ShouldBeNil)
+					So(total, ShouldEqual, 0)
+					So(err, ShouldEqual, appErrors.ErrJobNumberMustBeInt)
 				})
 			})
 		})

--- a/application/application.go
+++ b/application/application.go
@@ -25,6 +25,7 @@ type JobService interface {
 	UpdateJobState(ctx context.Context, jobNumber int, newState domain.State, userID string) error
 	UpdateJobCollectionID(ctx context.Context, jobNumber int, collectionID string) error
 	GetJobs(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error)
+	GetJobStatesSummary(ctx context.Context) ([]domain.StateSummary, error)
 	GetJobTasks(ctx context.Context, states []domain.State, jobNumber int, limit, offset int) ([]*domain.Task, int, error)
 	CreateTask(ctx context.Context, jobNumber int, task *domain.Task) (*domain.Task, error)
 	UpdateTask(ctx context.Context, task *domain.Task) error
@@ -174,6 +175,30 @@ func (js *jobService) UpdateJobState(ctx context.Context, jobNumber int, newStat
 // GetJobs retrieves a list of migration jobs with pagination.
 func (js *jobService) GetJobs(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
 	return js.store.GetJobs(ctx, field, direction, states, limit, offset)
+}
+
+// GetJobStatesSummary retrieves a summary of job counts by state.
+func (js *jobService) GetJobStatesSummary(ctx context.Context) ([]domain.StateSummary, error) {
+	jobStateCounts, err := js.store.GetJobStateCounts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get job state counts: %w", err)
+	}
+
+	stateSummaries := make([]domain.StateSummary, len(jobStateCounts))
+	for i, result := range jobStateCounts {
+		label, err := domain.GetStateLabel(result.State)
+		if err != nil {
+			return nil, err
+		}
+
+		stateSummaries[i] = domain.StateSummary{
+			ID:    result.State,
+			Label: label,
+			Count: result.Count,
+		}
+	}
+
+	return stateSummaries, nil
 }
 
 // ClaimJob claims a pending job for processing.

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ONSdigital/dis-migration-service/domain"
 	domainMocks "github.com/ONSdigital/dis-migration-service/domain/mock"
 	appErrors "github.com/ONSdigital/dis-migration-service/errors"
+	"github.com/ONSdigital/dis-migration-service/mongo"
 	"github.com/ONSdigital/dis-migration-service/store"
 	storeMocks "github.com/ONSdigital/dis-migration-service/store/mock"
 	. "github.com/smartystreets/goconvey/convey"
@@ -1134,6 +1135,156 @@ func TestGetJobs(t *testing.T) {
 						So(len(jobs), ShouldEqual, 0)
 						So(totalCount, ShouldEqual, 0)
 					})
+				})
+			})
+		})
+	})
+}
+
+func TestGetJobStatesSummary(t *testing.T) {
+	Convey("Given a job service and store that returns a summary of job states", t, func() {
+		mockMongo := &storeMocks.MongoDBMock{
+			GetJobStateCountsFunc: func(ctx context.Context) ([]mongo.StateCountResult, error) {
+				return []mongo.StateCountResult{
+					{State: domain.StateSubmitted, Count: 5},
+					{State: domain.StateApproved, Count: 3},
+					{State: domain.StateCompleted, Count: 2},
+				}, nil
+			},
+		}
+
+		mockStore := store.Datastore{
+			Backend: mockMongo,
+		}
+
+		mockClients := clients.ClientList{}
+		cfg := &config.Config{}
+		jobService := Setup(&mockStore, &mockClients, cfg)
+
+		ctx := context.Background()
+
+		Convey("When GetJobStatesSummary is called", func() {
+			stateSummaries, err := jobService.GetJobStatesSummary(ctx)
+
+			Convey("Then the store should be called", func() {
+				So(len(mockMongo.GetJobStateCountsCalls()), ShouldEqual, 1)
+
+				Convey("Then no error should be returned", func() {
+					So(err, ShouldBeNil)
+
+					Convey("And the summaries should be returned correctly", func() {
+						So(len(stateSummaries), ShouldEqual, 3)
+						So(stateSummaries[0].ID, ShouldEqual, domain.StateSubmitted)
+						So(stateSummaries[0].Label, ShouldEqual, "Submitted")
+						So(stateSummaries[0].Count, ShouldEqual, 5)
+						So(stateSummaries[1].ID, ShouldEqual, domain.StateApproved)
+						So(stateSummaries[1].Label, ShouldEqual, "Approved")
+						So(stateSummaries[1].Count, ShouldEqual, 3)
+						So(stateSummaries[2].ID, ShouldEqual, domain.StateCompleted)
+						So(stateSummaries[2].Label, ShouldEqual, "Completed")
+						So(stateSummaries[2].Count, ShouldEqual, 2)
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given a job service and store that returns an error when getting job state counts", t, func() {
+		mockMongo := &storeMocks.MongoDBMock{
+			GetJobStateCountsFunc: func(ctx context.Context) ([]mongo.StateCountResult, error) {
+				return nil, errors.New("database error")
+			},
+		}
+
+		mockStore := store.Datastore{
+			Backend: mockMongo,
+		}
+
+		mockClients := clients.ClientList{}
+		cfg := &config.Config{}
+		jobService := Setup(&mockStore, &mockClients, cfg)
+
+		ctx := context.Background()
+
+		Convey("When GetJobStatesSummary is called", func() {
+			stateSummaries, err := jobService.GetJobStatesSummary(ctx)
+
+			Convey("Then the store should be called", func() {
+				So(len(mockMongo.GetJobStateCountsCalls()), ShouldEqual, 1)
+
+				Convey("Then an error should be returned", func() {
+					So(stateSummaries, ShouldBeNil)
+					So(err, ShouldNotBeNil)
+					So(err.Error(), ShouldContainSubstring, "failed to get job state counts")
+				})
+			})
+		})
+	})
+
+	Convey("Given a job service and store that returns an empty list of job state counts", t, func() {
+		mockMongo := &storeMocks.MongoDBMock{
+			GetJobStateCountsFunc: func(ctx context.Context) ([]mongo.StateCountResult, error) {
+				return []mongo.StateCountResult{}, nil
+			},
+		}
+
+		mockStore := store.Datastore{
+			Backend: mockMongo,
+		}
+
+		mockClients := clients.ClientList{}
+		cfg := &config.Config{}
+		jobService := Setup(&mockStore, &mockClients, cfg)
+
+		ctx := context.Background()
+
+		Convey("When GetJobStatesSummary is called", func() {
+			stateSummaries, err := jobService.GetJobStatesSummary(ctx)
+
+			Convey("Then the store should be called", func() {
+				So(len(mockMongo.GetJobStateCountsCalls()), ShouldEqual, 1)
+
+				Convey("Then no error should be returned", func() {
+					So(err, ShouldBeNil)
+
+					Convey("And an empty list should be returned", func() {
+						So(stateSummaries, ShouldNotBeNil)
+						So(len(stateSummaries), ShouldEqual, 0)
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given a job service and store that returns a job state count with an unknown state", t, func() {
+		mockMongo := &storeMocks.MongoDBMock{
+			GetJobStateCountsFunc: func(ctx context.Context) ([]mongo.StateCountResult, error) {
+				return []mongo.StateCountResult{
+					{State: "unknown_state", Count: 5},
+				}, nil
+			},
+		}
+
+		mockStore := store.Datastore{
+			Backend: mockMongo,
+		}
+
+		mockClients := clients.ClientList{}
+		cfg := &config.Config{}
+		jobService := Setup(&mockStore, &mockClients, cfg)
+
+		ctx := context.Background()
+
+		Convey("When GetJobStatesSummary is called", func() {
+			stateSummaries, err := jobService.GetJobStatesSummary(ctx)
+
+			Convey("Then the store should be called", func() {
+				So(len(mockMongo.GetJobStateCountsCalls()), ShouldEqual, 1)
+
+				Convey("Then an error should be returned", func() {
+					So(stateSummaries, ShouldBeNil)
+					So(err, ShouldNotBeNil)
+					So(err.Error(), ShouldContainSubstring, "unknown state label mapping for state: unknown_state")
 				})
 			})
 		})

--- a/application/mock/jobservice.go
+++ b/application/mock/jobservice.go
@@ -48,6 +48,9 @@ var _ application.JobService = &JobServiceMock{}
 //			GetJobEventsFunc: func(ctx context.Context, jobNumber int, limit int, offset int) ([]*domain.Event, int, error) {
 //				panic("mock out the GetJobEvents method")
 //			},
+//			GetJobStatesSummaryFunc: func(ctx context.Context) ([]domain.StateSummary, error) {
+//				panic("mock out the GetJobStatesSummary method")
+//			},
 //			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber int, limit int, offset int) ([]*domain.Task, int, error) {
 //				panic("mock out the GetJobTasks method")
 //			},
@@ -102,6 +105,9 @@ type JobServiceMock struct {
 
 	// GetJobEventsFunc mocks the GetJobEvents method.
 	GetJobEventsFunc func(ctx context.Context, jobNumber int, limit int, offset int) ([]*domain.Event, int, error)
+
+	// GetJobStatesSummaryFunc mocks the GetJobStatesSummary method.
+	GetJobStatesSummaryFunc func(ctx context.Context) ([]domain.StateSummary, error)
 
 	// GetJobTasksFunc mocks the GetJobTasks method.
 	GetJobTasksFunc func(ctx context.Context, states []domain.State, jobNumber int, limit int, offset int) ([]*domain.Task, int, error)
@@ -197,6 +203,11 @@ type JobServiceMock struct {
 			// Offset is the offset argument value.
 			Offset int
 		}
+		// GetJobStatesSummary holds details about calls to the GetJobStatesSummary method.
+		GetJobStatesSummary []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
 		// GetJobTasks holds details about calls to the GetJobTasks method.
 		GetJobTasks []struct {
 			// Ctx is the ctx argument value.
@@ -276,6 +287,7 @@ type JobServiceMock struct {
 	lockCreateTask             sync.RWMutex
 	lockGetJob                 sync.RWMutex
 	lockGetJobEvents           sync.RWMutex
+	lockGetJobStatesSummary    sync.RWMutex
 	lockGetJobTasks            sync.RWMutex
 	lockGetJobs                sync.RWMutex
 	lockGetNextJobNumber       sync.RWMutex
@@ -622,6 +634,38 @@ func (mock *JobServiceMock) GetJobEventsCalls() []struct {
 	mock.lockGetJobEvents.RLock()
 	calls = mock.calls.GetJobEvents
 	mock.lockGetJobEvents.RUnlock()
+	return calls
+}
+
+// GetJobStatesSummary calls GetJobStatesSummaryFunc.
+func (mock *JobServiceMock) GetJobStatesSummary(ctx context.Context) ([]domain.StateSummary, error) {
+	if mock.GetJobStatesSummaryFunc == nil {
+		panic("JobServiceMock.GetJobStatesSummaryFunc: method is nil but JobService.GetJobStatesSummary was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetJobStatesSummary.Lock()
+	mock.calls.GetJobStatesSummary = append(mock.calls.GetJobStatesSummary, callInfo)
+	mock.lockGetJobStatesSummary.Unlock()
+	return mock.GetJobStatesSummaryFunc(ctx)
+}
+
+// GetJobStatesSummaryCalls gets all the calls that were made to GetJobStatesSummary.
+// Check the length with:
+//
+//	len(mockedJobService.GetJobStatesSummaryCalls())
+func (mock *JobServiceMock) GetJobStatesSummaryCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetJobStatesSummary.RLock()
+	calls = mock.calls.GetJobStatesSummary
+	mock.lockGetJobStatesSummary.RUnlock()
 	return calls
 }
 

--- a/domain/state.go
+++ b/domain/state.go
@@ -1,5 +1,9 @@
 package domain
 
+import (
+	"fmt"
+)
+
 // State represents the various states a migration job can be in.
 type State string
 
@@ -56,7 +60,7 @@ func IsValidState(state State) bool {
 // 'cancelled' state.
 func GetNonCancelledStates() []State {
 	return []State{
-		StateSubmitted, StateInReview, StateApproved, StatePublished,
+		StateSubmitted, StateInReview, StateApproved, StateRejected, StatePublished,
 		StateCompleted, StateMigrating, StatePublishing, StatePostPublishing,
 		StateReverting, StateFailedMigration, StateFailedPostPublish, StateFailedPublish, StateFailedReversion,
 	}
@@ -69,5 +73,43 @@ func IsFailedState(state State) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// GetStateLabel returns a human readable label for the given State.
+func GetStateLabel(state State) (string, error) {
+	switch state {
+	case StateSubmitted:
+		return "Submitted", nil
+	case StateInReview:
+		return "In review", nil
+	case StateApproved:
+		return "Approved", nil
+	case StateRejected:
+		return "Rejected", nil
+	case StatePublished:
+		return "Published", nil
+	case StateCompleted:
+		return "Completed", nil
+	case StateMigrating:
+		return "Migrating", nil
+	case StatePublishing:
+		return "Publishing", nil
+	case StatePostPublishing:
+		return "Post-publishing", nil
+	case StateReverting:
+		return "Reverting", nil
+	case StateFailedPostPublish:
+		return "Failed post-publish", nil
+	case StateFailedPublish:
+		return "Failed publish", nil
+	case StateFailedMigration:
+		return "Failed migration", nil
+	case StateFailedReversion:
+		return "Failed reversion", nil
+	case StateCancelled:
+		return "Cancelled", nil
+	default:
+		return "", fmt.Errorf("unknown state label mapping for state: %s", state)
 	}
 }

--- a/domain/state_summary.go
+++ b/domain/state_summary.go
@@ -1,0 +1,8 @@
+package domain
+
+// StateSummary represents a summary count for a given state.
+type StateSummary struct {
+	ID    State  `json:"id" bson:"_id"`
+	Label string `json:"label" bson:"label"`
+	Count int    `json:"count" bson:"count"`
+}

--- a/domain/state_summary.go
+++ b/domain/state_summary.go
@@ -1,6 +1,6 @@
 package domain
 
-// StateSummary represents a summary count for a given state.
+// StateSummary represents the summary information for a given state.
 type StateSummary struct {
 	ID    State  `json:"id" bson:"_id"`
 	Label string `json:"label" bson:"label"`

--- a/features/get_job.feature
+++ b/features/get_job.feature
@@ -41,6 +41,21 @@ Feature: Get a Job
         }
         """
 
+    @InvalidInput
+    Scenario: Get a job with an invalid job number
+      When I GET "/v1/migration-jobs/invalid-job-number"
+      Then I should receive the following JSON response with status "400":
+        """
+        {
+          "errors": [
+            {
+              "code": 400,
+              "description": "job number must be an integer"
+            }
+          ]
+        }
+        """
+
     Scenario: Get a job which doesn't exist
       When I GET "/v1/migration-jobs/4000"
       Then I should receive the following JSON response with status "404":

--- a/features/get_job_events.feature
+++ b/features/get_job_events.feature
@@ -179,6 +179,21 @@ Feature: Get list of job events
         }
         """
 
+    @InvalidInput
+    Scenario: Get a list of events with an invalid job number
+      When I GET "/v1/migration-jobs/invalid-job-number/events"
+      Then I should receive the following JSON response with status "400":
+        """
+        {
+          "errors": [
+            {
+              "code": 400,
+              "description": "job number must be an integer"
+            }
+          ]
+        }
+        """
+
     @Auth
     Rule: Users that are not authorised or authenticated
     Background:

--- a/features/get_job_tasks.feature
+++ b/features/get_job_tasks.feature
@@ -589,6 +589,21 @@ Feature: Get list of job tasks
           ]
         }
         """
+    
+    @InvalidInput
+    Scenario: Get a list of tasks with an invalid job number
+      When I GET "/v1/migration-jobs/invalid-job-number/tasks"
+      Then I should receive the following JSON response with status "400":
+        """
+        {
+          "errors": [
+            {
+              "code": 400,
+              "description": "job number must be an integer"
+            }
+          ]
+        }
+        """
 
     @InvalidInput
     Scenario: Get a list of tasks with limit exceeding maximum allowed

--- a/features/get_jobs.feature
+++ b/features/get_jobs.feature
@@ -52,6 +52,13 @@ Feature: Get list of jobs
               }
             }
           ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            }
+          ],
           "limit": 10,
           "offset": 0,
           "total_count": 1
@@ -92,7 +99,7 @@ Feature: Get list of jobs
               "href": "/v1/migration-jobs/33"
             }
           },
-          "state": "in_progress",
+          "state": "publishing",
           "config": {
             "source_id": "another-source-id",
             "target_id": "another-target-id",
@@ -116,7 +123,7 @@ Feature: Get list of jobs
                   "href": "/v1/migration-jobs/33"
                 }
               },
-              "state": "in_progress",
+              "state": "publishing",
               "config": {
                 "source_id": "another-source-id",
                 "target_id": "another-target-id",
@@ -139,6 +146,18 @@ Feature: Get list of jobs
                 "target_id": "test-target-id",
                 "type": "test-type"
               }
+            }
+          ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            },
+            {
+              "id": "publishing",
+              "label": "Publishing",
+              "count": 1
             }
           ],
           "limit": 10,
@@ -170,6 +189,18 @@ Feature: Get list of jobs
               }
             }
           ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            },
+            {
+              "id": "publishing",
+              "label": "Publishing",
+              "count": 1
+            }
+          ],
           "limit": 1,
           "offset": 1,
           "total_count": 2
@@ -191,12 +222,24 @@ Feature: Get list of jobs
                   "href": "/v1/migration-jobs/33"
                 }
               },
-              "state": "in_progress",
+              "state": "publishing",
               "config": {
                 "source_id": "another-source-id",
                 "target_id": "another-target-id",
                 "type": "another-type"
               }
+            }
+          ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            },
+            {
+              "id": "publishing",
+              "label": "Publishing",
+              "count": 1
             }
           ],
           "limit": 1,
@@ -224,11 +267,11 @@ Feature: Get list of jobs
       And the following document exists in the "jobs" collection:
         """
         {
-          "_id": "job-approved-1",
+          "_id": "job-published-1",
           "job_number": 24,
-          "label": "job-approved-1",
+          "label": "job-published-1",
           "last_updated": "2025-11-19T14:00:00Z",
-          "state": "approved",
+          "state": "published",
           "config": {
             "source_id": "s2",
             "target_id": "t2",
@@ -236,24 +279,36 @@ Feature: Get list of jobs
           }
         }
         """
-      When I GET "/v1/migration-jobs?state=migrating"
+      When I GET "/v1/migration-jobs?state=published"
       Then I should receive the following JSON response with status "200":
         """
         {
           "count": 1,
           "items": [
             {
-              "id": "job-submitted-1",
-              "job_number": 23,
-              "label": "job-submitted-1",
-              "state": "migrating",
+              "id": "job-published-1",
+              "job_number": 24,
+              "label": "job-published-1",
+              "state": "published",
               "config": {
-                "source_id": "s1",
-                "target_id": "t1",
-                "type": "type1"
+                "source_id": "s2",
+                "target_id": "t2",
+                "type": "type2"
               },
-              "last_updated": "2025-11-19T13:28:00Z",
+              "last_updated": "2025-11-19T14:00:00Z",
               "links": {}
+            }
+          ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            },
+            {
+              "id": "published",
+              "label": "Published",
+              "count": 1
             }
           ],
           "limit": 10,
@@ -326,6 +381,18 @@ Feature: Get list of jobs
               }
             }
           ],
+          "states": [
+            {
+              "id": "in_review",
+              "label": "In review",
+              "count": 1
+            },
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            }
+          ],
           "limit": 10,
           "offset": 0,
           "total_count": 2
@@ -396,6 +463,18 @@ Feature: Get list of jobs
               }
             }
           ],
+          "states": [
+            {
+              "id": "in_review",
+              "label": "In review",
+              "count": 1
+            },
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            }
+          ],
           "limit": 10,
           "offset": 0,
           "total_count": 2
@@ -434,7 +513,7 @@ Feature: Get list of jobs
               "href": "/v1/migration-jobs/33"
             }
           },
-          "state": "in_progress",
+          "state": "publishing",
           "config": {
             "source_id": "another-source-id",
             "target_id": "another-target-id",
@@ -458,7 +537,7 @@ Feature: Get list of jobs
                   "href": "/v1/migration-jobs/33"
                 }
               },
-              "state": "in_progress",
+              "state": "publishing",
               "config": {
                 "source_id": "another-source-id",
                 "target_id": "another-target-id",
@@ -481,6 +560,18 @@ Feature: Get list of jobs
                 "target_id": "test-target-id",
                 "type": "test-type"
               }
+            }
+          ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            },
+            {
+              "id": "publishing",
+              "label": "Publishing",
+              "count": 1
             }
           ],
           "limit": 10,
@@ -521,12 +612,24 @@ Feature: Get list of jobs
                   "href": "/v1/migration-jobs/33"
                 }
               },
-              "state": "in_progress",
+              "state": "publishing",
               "config": {
                 "source_id": "another-source-id",
                 "target_id": "another-target-id",
                 "type": "another-type"
               }
+            }
+          ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            },
+            {
+              "id": "publishing",
+              "label": "Publishing",
+              "count": 1
             }
           ],
           "limit": 10,
@@ -567,12 +670,24 @@ Feature: Get list of jobs
                   "href": "/v1/migration-jobs/33"
                 }
               },
-              "state": "in_progress",
+              "state": "publishing",
               "config": {
                 "source_id": "another-source-id",
                 "target_id": "another-target-id",
                 "type": "another-type"
               }
+            }
+          ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            },
+            {
+              "id": "publishing",
+              "label": "Publishing",
+              "count": 1
             }
           ],
           "limit": 10,
@@ -596,7 +711,7 @@ Feature: Get list of jobs
                   "href": "/v1/migration-jobs/33"
                 }
               },
-              "state": "in_progress",
+              "state": "publishing",
               "config": {
                 "source_id": "another-source-id",
                 "target_id": "another-target-id",
@@ -619,6 +734,18 @@ Feature: Get list of jobs
                 "target_id": "test-target-id",
                 "type": "test-type"
               }
+            }
+          ],
+          "states": [
+            {
+              "id": "migrating",
+              "label": "Migrating",
+              "count": 1
+            },
+            {
+              "id": "publishing",
+              "label": "Publishing",
+              "count": 1
             }
           ],
           "limit": 10,
@@ -713,6 +840,7 @@ Feature: Get list of jobs
         {
           "count": 0,
           "items": [],
+          "states": [],
           "limit": 10,
           "offset": 0,
           "total_count": 0

--- a/mongo/job_store.go
+++ b/mongo/job_store.go
@@ -15,6 +15,13 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// StateCountResult represents the result of a MongoDB aggregation that counts
+// the number of jobs in each state.
+type StateCountResult struct {
+	State domain.State `bson:"_id"`
+	Count int          `bson:"count"`
+}
+
 // CreateJob creates a new migration job.
 func (m *Mongo) CreateJob(ctx context.Context, job *domain.Job) error {
 	_, err := m.Connection.Collection(m.ActualCollectionName(config.JobsCollectionTitle)).InsertOne(ctx, job)
@@ -74,6 +81,34 @@ func (m *Mongo) GetJobs(ctx context.Context, field sort.SortParameterField, dire
 		)
 
 	return results, totalCount, err
+}
+
+// GetJobStateCounts retrieves a summary of job counts by state, sorted by count
+// descending.
+func (m *Mongo) GetJobStateCounts(ctx context.Context) ([]StateCountResult, error) {
+	var results []StateCountResult
+
+	pipeline := mongo.Pipeline{
+		{
+			{Key: "$group", Value: bson.D{
+				{Key: "_id", Value: "$state"},
+				{Key: "count", Value: bson.D{
+					{Key: "$sum", Value: 1},
+				}},
+			}},
+		},
+		{
+			{Key: "$sort", Value: bson.D{
+				{Key: "count", Value: -1}, // Sort by count descending
+				{Key: "_id", Value: 1},    // If counts are equal, sort by state ascending
+			}},
+		},
+	}
+
+	err := m.Connection.Collection(m.ActualCollectionName(config.JobsCollectionTitle)).
+		Aggregate(ctx, pipeline, &results)
+
+	return results, err
 }
 
 // GetJobsBySourceOrTargetAndState retrieves jobs based on the provided

--- a/store/mock/datastore.go
+++ b/store/mock/datastore.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	sort "github.com/ONSdigital/dis-migration-service/api/sort"
 	"github.com/ONSdigital/dis-migration-service/domain"
+	"github.com/ONSdigital/dis-migration-service/mongo"
 	"github.com/ONSdigital/dis-migration-service/store"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"sync"
@@ -55,6 +56,9 @@ var _ store.Storer = &StorerMock{}
 //			},
 //			GetJobEventsFunc: func(ctx context.Context, jobNumber int, limit int, offset int) ([]*domain.Event, int, error) {
 //				panic("mock out the GetJobEvents method")
+//			},
+//			GetJobStateCountsFunc: func(ctx context.Context) ([]mongo.StateCountResult, error) {
+//				panic("mock out the GetJobStateCounts method")
 //			},
 //			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber int, limit int, offset int) ([]*domain.Task, int, error) {
 //				panic("mock out the GetJobTasks method")
@@ -122,6 +126,9 @@ type StorerMock struct {
 
 	// GetJobEventsFunc mocks the GetJobEvents method.
 	GetJobEventsFunc func(ctx context.Context, jobNumber int, limit int, offset int) ([]*domain.Event, int, error)
+
+	// GetJobStateCountsFunc mocks the GetJobStateCounts method.
+	GetJobStateCountsFunc func(ctx context.Context) ([]mongo.StateCountResult, error)
 
 	// GetJobTasksFunc mocks the GetJobTasks method.
 	GetJobTasksFunc func(ctx context.Context, states []domain.State, jobNumber int, limit int, offset int) ([]*domain.Task, int, error)
@@ -235,6 +242,11 @@ type StorerMock struct {
 			// Offset is the offset argument value.
 			Offset int
 		}
+		// GetJobStateCounts holds details about calls to the GetJobStateCounts method.
+		GetJobStateCounts []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
 		// GetJobTasks holds details about calls to the GetJobTasks method.
 		GetJobTasks []struct {
 			// Ctx is the ctx argument value.
@@ -338,6 +350,7 @@ type StorerMock struct {
 	lockCreateTask                      sync.RWMutex
 	lockGetJob                          sync.RWMutex
 	lockGetJobEvents                    sync.RWMutex
+	lockGetJobStateCounts               sync.RWMutex
 	lockGetJobTasks                     sync.RWMutex
 	lockGetJobs                         sync.RWMutex
 	lockGetJobsBySourceOrTargetAndState sync.RWMutex
@@ -754,6 +767,38 @@ func (mock *StorerMock) GetJobEventsCalls() []struct {
 	mock.lockGetJobEvents.RLock()
 	calls = mock.calls.GetJobEvents
 	mock.lockGetJobEvents.RUnlock()
+	return calls
+}
+
+// GetJobStateCounts calls GetJobStateCountsFunc.
+func (mock *StorerMock) GetJobStateCounts(ctx context.Context) ([]mongo.StateCountResult, error) {
+	if mock.GetJobStateCountsFunc == nil {
+		panic("StorerMock.GetJobStateCountsFunc: method is nil but Storer.GetJobStateCounts was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetJobStateCounts.Lock()
+	mock.calls.GetJobStateCounts = append(mock.calls.GetJobStateCounts, callInfo)
+	mock.lockGetJobStateCounts.Unlock()
+	return mock.GetJobStateCountsFunc(ctx)
+}
+
+// GetJobStateCountsCalls gets all the calls that were made to GetJobStateCounts.
+// Check the length with:
+//
+//	len(mockedStorer.GetJobStateCountsCalls())
+func (mock *StorerMock) GetJobStateCountsCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetJobStateCounts.RLock()
+	calls = mock.calls.GetJobStateCounts
+	mock.lockGetJobStateCounts.RUnlock()
 	return calls
 }
 

--- a/store/mock/mongo.go
+++ b/store/mock/mongo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	sort "github.com/ONSdigital/dis-migration-service/api/sort"
 	"github.com/ONSdigital/dis-migration-service/domain"
+	"github.com/ONSdigital/dis-migration-service/mongo"
 	"github.com/ONSdigital/dis-migration-service/store"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"sync"
@@ -55,6 +56,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			},
 //			GetJobEventsFunc: func(ctx context.Context, jobNumber int, limit int, offset int) ([]*domain.Event, int, error) {
 //				panic("mock out the GetJobEvents method")
+//			},
+//			GetJobStateCountsFunc: func(ctx context.Context) ([]mongo.StateCountResult, error) {
+//				panic("mock out the GetJobStateCounts method")
 //			},
 //			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber int, limit int, offset int) ([]*domain.Task, int, error) {
 //				panic("mock out the GetJobTasks method")
@@ -122,6 +126,9 @@ type MongoDBMock struct {
 
 	// GetJobEventsFunc mocks the GetJobEvents method.
 	GetJobEventsFunc func(ctx context.Context, jobNumber int, limit int, offset int) ([]*domain.Event, int, error)
+
+	// GetJobStateCountsFunc mocks the GetJobStateCounts method.
+	GetJobStateCountsFunc func(ctx context.Context) ([]mongo.StateCountResult, error)
 
 	// GetJobTasksFunc mocks the GetJobTasks method.
 	GetJobTasksFunc func(ctx context.Context, states []domain.State, jobNumber int, limit int, offset int) ([]*domain.Task, int, error)
@@ -235,6 +242,11 @@ type MongoDBMock struct {
 			// Offset is the offset argument value.
 			Offset int
 		}
+		// GetJobStateCounts holds details about calls to the GetJobStateCounts method.
+		GetJobStateCounts []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
 		// GetJobTasks holds details about calls to the GetJobTasks method.
 		GetJobTasks []struct {
 			// Ctx is the ctx argument value.
@@ -338,6 +350,7 @@ type MongoDBMock struct {
 	lockCreateTask                      sync.RWMutex
 	lockGetJob                          sync.RWMutex
 	lockGetJobEvents                    sync.RWMutex
+	lockGetJobStateCounts               sync.RWMutex
 	lockGetJobTasks                     sync.RWMutex
 	lockGetJobs                         sync.RWMutex
 	lockGetJobsBySourceOrTargetAndState sync.RWMutex
@@ -754,6 +767,38 @@ func (mock *MongoDBMock) GetJobEventsCalls() []struct {
 	mock.lockGetJobEvents.RLock()
 	calls = mock.calls.GetJobEvents
 	mock.lockGetJobEvents.RUnlock()
+	return calls
+}
+
+// GetJobStateCounts calls GetJobStateCountsFunc.
+func (mock *MongoDBMock) GetJobStateCounts(ctx context.Context) ([]mongo.StateCountResult, error) {
+	if mock.GetJobStateCountsFunc == nil {
+		panic("MongoDBMock.GetJobStateCountsFunc: method is nil but MongoDB.GetJobStateCounts was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetJobStateCounts.Lock()
+	mock.calls.GetJobStateCounts = append(mock.calls.GetJobStateCounts, callInfo)
+	mock.lockGetJobStateCounts.Unlock()
+	return mock.GetJobStateCountsFunc(ctx)
+}
+
+// GetJobStateCountsCalls gets all the calls that were made to GetJobStateCounts.
+// Check the length with:
+//
+//	len(mockedMongoDB.GetJobStateCountsCalls())
+func (mock *MongoDBMock) GetJobStateCountsCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetJobStateCounts.RLock()
+	calls = mock.calls.GetJobStateCounts
+	mock.lockGetJobStateCounts.RUnlock()
 	return calls
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -6,6 +6,7 @@ import (
 
 	sort "github.com/ONSdigital/dis-migration-service/api/sort"
 	"github.com/ONSdigital/dis-migration-service/domain"
+	"github.com/ONSdigital/dis-migration-service/mongo"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 )
 
@@ -23,6 +24,7 @@ type dataMongoDB interface {
 	CreateJob(ctx context.Context, job *domain.Job) error
 	GetJob(ctx context.Context, jobNumber int) (*domain.Job, error)
 	GetJobs(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error)
+	GetJobStateCounts(ctx context.Context) ([]mongo.StateCountResult, error)
 	ClaimJob(ctx context.Context, pendingState domain.State, activeState domain.State) (*domain.Job, error)
 	GetJobsBySourceOrTargetAndState(ctx context.Context, jc *domain.JobConfig, states []domain.State, limit, offset int) ([]*domain.Job, error)
 	GetNextJobNumberCounter(ctx context.Context) (*domain.Counter, error)
@@ -89,6 +91,12 @@ func (ds *Datastore) UpdateJob(ctx context.Context, job *domain.Job) error {
 // GetJobs retrieves a list of migration jobs with pagination.
 func (ds *Datastore) GetJobs(ctx context.Context, field sort.SortParameterField, direction sort.SortParameterDirection, states []domain.State, limit, offset int) ([]*domain.Job, int, error) {
 	return ds.Backend.GetJobs(ctx, field, direction, states, limit, offset)
+}
+
+// GetJobStateCounts retrieves a summary of job counts by state, sorted by count
+// descending.
+func (ds *Datastore) GetJobStateCounts(ctx context.Context) ([]mongo.StateCountResult, error) {
+	return ds.Backend.GetJobStateCounts(ctx)
 }
 
 // GetJobsBySourceOrTargetAndState retrieves jobs based on the provided

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -521,7 +521,7 @@ definitions:
     properties:
       id:
         type: string
-        example: 1
+        example: "1"
       last_updated:
         type: string
         format: date-time
@@ -540,7 +540,7 @@ definitions:
     properties:
       id:
         type: string
-        example: 1
+        example: "1"
       label:
         type: string
         example: "Consumer price inflation tables"
@@ -558,6 +558,11 @@ definitions:
             description: Array containing results.
             items:
               $ref: "#/definitions/MigrationJob"
+          states:
+            type: array
+            description: An array of states found in the full result set
+            items:
+              $ref: "#/definitions/StateSummary"
 
   MigrationTaskList:
     allOf:
@@ -610,7 +615,7 @@ definitions:
       jobId:
         description: The ID of the job this event took place on.
         type: string
-        example: 1
+        example: "1"
 
   List:
     type: object
@@ -627,6 +632,22 @@ definitions:
       total_count:
         type: integer
         description: How many jobs are available in total
+
+  StateSummary:
+    type: object
+    properties:
+      id:
+        type: string
+        description: A computer usable key for this state
+        example: in_review
+      label:
+        type: string
+        description: A human readable label for this state
+        example: In review
+      count:
+        type: integer
+        description: The number of results of this state type within the full set of results.
+        example: 1
 
   MigrationState:
     type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -560,7 +560,7 @@ definitions:
               $ref: "#/definitions/MigrationJob"
           states:
             type: array
-            description: An array of states found in the full result set
+            description: An array of summaries of the states found in the full result set.
             items:
               $ref: "#/definitions/StateSummary"
 
@@ -646,7 +646,7 @@ definitions:
         example: In review
       count:
         type: integer
-        description: The number of results of this state type within the full set of results.
+        description: The number of results with this state within the full set of results.
         example: 1
 
   MigrationState:


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4876

- When making requests to `GET /migration-jobs`, a `states` array is returned in the response body containing a summary showing the number of jobs (non-zero) in each state.

Other changes:
- Updated `GET /migration-jobs/{job_number}/events` and `GET /migration-jobs/{job_number}/tasks` to return the correct error when the job number is invalid. Previously these would return a 500 error due to not using a defined appError. Both endpoints also had an extra call to `handleError()`
- `GetNonCancelledStates()` did not include the `rejected` state so that has been added into the function

Notes:
- The `GetJobStateCounts` query will order states by count. Ticket did not specify what ordering is needed so count was chosen to keep component tests deterministic.

### How to review

- Create a bunch of migration jobs in different states. (Can be done by manually adding documents into Mongo as we are only testing a `GET` method here)
- Make requests to `GET /migration-jobs` using different query params. All successful requests should return the `states` array exactly the same. (summary of all jobs, not just the ones returned)
- Test `GET /migration-jobs/{job_number}/events` and `GET /migration-jobs/{job_number}/tasks` return the expected errors when the job number is invalid

### Who can review

- Anyone
