### PR TITLE
Adjusted post publish functionality

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -291,6 +291,7 @@ func (js *jobService) ClaimTask(ctx context.Context) (*domain.Task, error) {
 	}{
 		{from: domain.StateSubmitted, to: domain.StateMigrating},
 		{from: domain.StateApproved, to: domain.StatePublishing},
+		{from: domain.StatePendingPostPublish, to: domain.StatePostPublishing},
 		{from: domain.StateRejected, to: domain.StateReverting},
 	}
 

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -2755,14 +2755,16 @@ func TestClaimTask(t *testing.T) {
 			task, err := jobService.ClaimTask(ctx)
 
 			Convey("Then the store should be called to claim a task", func() {
-				So(len(mockMongo.ClaimTaskCalls()), ShouldEqual, 3)
+				So(len(mockMongo.ClaimTaskCalls()), ShouldEqual, 4)
 				So(len(mockMongo.GetJobsCalls()), ShouldEqual, 0)
 				So(mockMongo.ClaimTaskCalls()[0].PendingState, ShouldEqual, domain.StateSubmitted)
 				So(mockMongo.ClaimTaskCalls()[0].ActiveState, ShouldEqual, domain.StateMigrating)
 				So(mockMongo.ClaimTaskCalls()[1].PendingState, ShouldEqual, domain.StateApproved)
 				So(mockMongo.ClaimTaskCalls()[1].ActiveState, ShouldEqual, domain.StatePublishing)
-				So(mockMongo.ClaimTaskCalls()[2].PendingState, ShouldEqual, domain.StateRejected)
-				So(mockMongo.ClaimTaskCalls()[2].ActiveState, ShouldEqual, domain.StateReverting)
+				So(mockMongo.ClaimTaskCalls()[2].PendingState, ShouldEqual, domain.StatePendingPostPublish)
+				So(mockMongo.ClaimTaskCalls()[2].ActiveState, ShouldEqual, domain.StatePostPublishing)
+				So(mockMongo.ClaimTaskCalls()[3].PendingState, ShouldEqual, domain.StateRejected)
+				So(mockMongo.ClaimTaskCalls()[3].ActiveState, ShouldEqual, domain.StateReverting)
 			})
 
 			Convey("And no error should be returned", func() {

--- a/domain/state.go
+++ b/domain/state.go
@@ -25,6 +25,8 @@ const (
 	StateMigrating State = "migrating"
 	// StatePublishing indicates a job or task is currently publishing
 	StatePublishing State = "publishing"
+	// StatePendingPostPublish indicates a task is pending post-publishing steps
+	StatePendingPostPublish State = "pending_post_publish"
 	// StatePostPublishing indicates a job or task is in post-publishing phase
 	StatePostPublishing State = "post_publishing"
 	// StateReverting indicates a job or task is being reverted
@@ -47,7 +49,7 @@ const (
 func IsValidState(state State) bool {
 	switch state {
 	case StateSubmitted, StateInReview, StateApproved, StateRejected, StatePublished,
-		StateCompleted, StateMigrating, StatePublishing, StatePostPublishing,
+		StateCompleted, StateMigrating, StatePublishing, StatePendingPostPublish, StatePostPublishing,
 		StateReverting, StateFailedMigration, StateFailedPostPublish, StateFailedPublish, StateFailedReversion,
 		StateCancelled:
 		return true
@@ -61,7 +63,7 @@ func IsValidState(state State) bool {
 func GetNonCancelledStates() []State {
 	return []State{
 		StateSubmitted, StateInReview, StateApproved, StateRejected, StatePublished,
-		StateCompleted, StateMigrating, StatePublishing, StatePostPublishing,
+		StateCompleted, StateMigrating, StatePublishing, StatePendingPostPublish, StatePostPublishing,
 		StateReverting, StateFailedMigration, StateFailedPostPublish, StateFailedPublish, StateFailedReversion,
 	}
 }
@@ -95,6 +97,8 @@ func GetStateLabel(state State) (string, error) {
 		return "Migrating", nil
 	case StatePublishing:
 		return "Publishing", nil
+	case StatePendingPostPublish:
+		return "Pending post-publish", nil
 	case StatePostPublishing:
 		return "Post-publishing", nil
 	case StateReverting:

--- a/executor/job_static_dataset.go
+++ b/executor/job_static_dataset.go
@@ -136,7 +136,15 @@ func (e *StaticDatasetJobExecutor) PostPublish(ctx context.Context, job *domain.
 	logData := log.Data{"job_number": job.JobNumber}
 	log.Info(ctx, "starting post-publishing for job", logData)
 
-	// update task state to post-publishing
+	// publishing zebedee collection
+	log.Info(ctx, "starting zebedee collection publish for job", logData)
+	err := e.clientList.Zebedee.PublishCollection(ctx, e.serviceAuthToken, job.Config.CollectionID)
+	if err != nil {
+		log.Error(ctx, "failed to publish collection in zebedee", err, logData)
+		return err
+	}
+
+	// update task state to pending post-publish
 	totalTasks, err := e.jobService.CountTasksByJobNumber(ctx, job.JobNumber)
 	if err != nil {
 		log.Error(ctx, "failed to count tasks", err, logData)
@@ -151,47 +159,13 @@ func (e *StaticDatasetJobExecutor) PostPublish(ctx context.Context, job *domain.
 	log.Info(ctx, "successfully got all job tasks", logData)
 
 	for _, task := range publishedTasks {
-		err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StatePostPublishing)
+		err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StatePendingPostPublish)
 		if err != nil {
 			log.Error(ctx, "failed to update task state", err, logData)
 			return err
 		}
 	}
-	log.Info(ctx, "successfully updated all job tasks state to post-publishing", logData)
-
-	// publishing zebedee collection
-	log.Info(ctx, "starting zebedee collection publish for job", logData)
-	err = e.clientList.Zebedee.PublishCollection(ctx, e.serviceAuthToken, job.Config.CollectionID)
-	if err != nil {
-		log.Error(ctx, "failed to publish collection in zebedee", err, logData)
-		return err
-	}
-
-	// update task state to completed
-
-	postPublishingTasks, _, err := e.jobService.GetJobTasks(ctx, []domain.State{domain.StatePostPublishing}, job.JobNumber, totalTasks, 0)
-	if err != nil {
-		log.Error(ctx, "failed to get job tasks", err, logData)
-		return err
-	}
-	log.Info(ctx, "successfully got all job tasks", logData)
-
-	for _, task := range postPublishingTasks {
-		err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StateCompleted)
-		if err != nil {
-			log.Error(ctx, "failed to update task state", err, logData)
-			return err
-		}
-	}
-	log.Info(ctx, "successfully updated all job tasks state to completed", logData)
-
-	// update job state to completed
-	err = e.jobService.UpdateJobState(ctx, job.JobNumber, domain.StateCompleted, "")
-	if err != nil {
-		log.Error(ctx, "failed to update job state to completed", err, logData)
-		return err
-	}
-	log.Info(ctx, "successfully updated job state to completed", logData)
+	log.Info(ctx, "successfully updated all job tasks state to pending post-publish", logData)
 
 	return nil
 }

--- a/executor/job_static_dataset_test.go
+++ b/executor/job_static_dataset_test.go
@@ -151,21 +151,11 @@ func TestJobStaticDataset(t *testing.T) {
 					So(mockZebedeeClient.PublishCollectionCalls()[0].CollectionID, ShouldEqual, testCollectionID)
 
 					Convey("And all tasks are updated to post-publishing then completed", func() {
-						So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 4)
+						So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 2)
 						So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, "task-1")
-						So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StatePostPublishing)
+						So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StatePendingPostPublish)
 						So(mockJobService.UpdateTaskStateCalls()[1].TaskID, ShouldEqual, "task-2")
-						So(mockJobService.UpdateTaskStateCalls()[1].NewState, ShouldEqual, domain.StatePostPublishing)
-						So(mockJobService.UpdateTaskStateCalls()[2].TaskID, ShouldEqual, "task-1")
-						So(mockJobService.UpdateTaskStateCalls()[2].NewState, ShouldEqual, domain.StateCompleted)
-						So(mockJobService.UpdateTaskStateCalls()[3].TaskID, ShouldEqual, "task-2")
-						So(mockJobService.UpdateTaskStateCalls()[3].NewState, ShouldEqual, domain.StateCompleted)
-
-						Convey("And the job state is updated to completed", func() {
-							So(mockJobService.UpdateJobStateCalls(), ShouldHaveLength, 1)
-							So(mockJobService.UpdateJobStateCalls()[0].JobNumber, ShouldEqual, testJobNumber)
-							So(mockJobService.UpdateJobStateCalls()[0].NewState, ShouldEqual, domain.StateCompleted)
-						})
+						So(mockJobService.UpdateTaskStateCalls()[1].NewState, ShouldEqual, domain.StatePendingPostPublish)
 					})
 				})
 			})
@@ -488,7 +478,7 @@ func TestJobStaticDataset(t *testing.T) {
 		Convey("When post-publish is called for a job", func() {
 			job := &domain.Job{
 				JobNumber: testJobNumber,
-				State:     domain.StatePostPublishing,
+				State:     domain.StatePendingPostPublish,
 				Config: &domain.JobConfig{
 					CollectionID: testCollectionID,
 				},
@@ -601,54 +591,6 @@ func TestJobStaticDataset(t *testing.T) {
 
 			Convey("Then an error is returned", func() {
 				So(err, ShouldEqual, errTest)
-			})
-		})
-	})
-
-	Convey("Given a static dataset job executor and a job service that errors when updating job state", t, func() {
-		mockJobService := &applicationMocks.JobServiceMock{
-			CountTasksByJobNumberFunc: func(ctx context.Context, jobNumber int) (int, error) {
-				return 2, nil
-			},
-			GetJobTasksFunc: func(ctx context.Context, states []domain.State, jobNumber, limit, offset int) ([]*domain.Task, int, error) {
-				return []*domain.Task{
-					{ID: "task-1", State: domain.StatePublished},
-					{ID: "task-2", State: domain.StatePublished},
-				}, 2, nil
-			},
-			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error {
-				return nil
-			},
-			UpdateJobStateFunc: func(ctx context.Context, jobNumber int, state domain.State, userID string) error {
-				return errTest
-			},
-		}
-		mockClientList := &clients.ClientList{
-			Zebedee: &clientMocks.ZebedeeClientMock{
-				PublishCollectionFunc: func(ctx context.Context, userAuthToken string, collectionID string) error {
-					return nil
-				},
-			},
-		}
-
-		ctx := context.Background()
-		executor := NewStaticDatasetJobExecutor(mockJobService, mockClientList, "faketoken")
-
-		Convey("When post-publish is called for a job", func() {
-			job := &domain.Job{
-				JobNumber: testJobNumber,
-				State:     domain.StatePostPublishing,
-				Config: &domain.JobConfig{
-					CollectionID: testCollectionID,
-				},
-			}
-
-			err := executor.PostPublish(ctx, job)
-
-			Convey("Then an error is returned", func() {
-				So(err, ShouldEqual, errTest)
-				So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 4)
-				So(mockJobService.UpdateJobStateCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})

--- a/executor/task_dataset_download.go
+++ b/executor/task_dataset_download.go
@@ -151,6 +151,15 @@ func (e *DatasetDownloadTaskExecutor) Publish(ctx context.Context, task *domain.
 // PostPublish handles the post-publish operations for a dataset download task.
 func (e *DatasetDownloadTaskExecutor) PostPublish(ctx context.Context, task *domain.Task) error {
 	// Implementation of post-publish for dataset download
+	logData := log.Data{"task_id": task.ID, "job_number": task.JobNumber}
+	log.Info(ctx, "updating task state to completed", logData)
+
+	err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StateCompleted)
+	if err != nil {
+		log.Error(ctx, "failed to update task state to completed", err, logData)
+		return err
+	}
+	log.Info(ctx, "successfully updated task state to completed", logData)
 	return nil
 }
 

--- a/executor/task_dataset_download_test.go
+++ b/executor/task_dataset_download_test.go
@@ -166,6 +166,20 @@ func TestDatasetDownloadTaskExecutor(t *testing.T) {
 					})
 				})
 			})
+
+			Convey("When post-publish is called for a download task", func() {
+				err := executor.PostPublish(ctx, testDownloadTask)
+
+				Convey("Then no error is returned", func() {
+					So(err, ShouldBeNil)
+
+					Convey("And the task state is updated to Completed", func() {
+						So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 1)
+						So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, testDownloadTask.ID)
+						So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StateCompleted)
+					})
+				})
+			})
 		})
 
 		Convey("And a dataset download task executor with a zebedee client mock that errors", func() {

--- a/executor/task_dataset_edition.go
+++ b/executor/task_dataset_edition.go
@@ -115,6 +115,15 @@ func (e *DatasetEditionTaskExecutor) Publish(ctx context.Context, task *domain.T
 // PostPublish handles the post-publish operations for a dataset edition task.
 func (e *DatasetEditionTaskExecutor) PostPublish(ctx context.Context, task *domain.Task) error {
 	// Implementation of post-publish for dataset edition
+	logData := log.Data{"task_id": task.ID, "job_number": task.JobNumber}
+	log.Info(ctx, "updating task state to completed", logData)
+
+	err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StateCompleted)
+	if err != nil {
+		log.Error(ctx, "failed to update task state to completed", err, logData)
+		return err
+	}
+	log.Info(ctx, "successfully updated task state to completed", logData)
 	return nil
 }
 

--- a/executor/task_dataset_edition_test.go
+++ b/executor/task_dataset_edition_test.go
@@ -102,6 +102,20 @@ func TestDatasetEditionTaskExecutor(t *testing.T) {
 				})
 			})
 		})
+
+		Convey("When post-publish is called for a task", func() {
+			err := executor.PostPublish(ctx, testEditionTask)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+
+				Convey("And the task state is updated to Completed", func() {
+					So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 1)
+					So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, testEditionTask.ID)
+					So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StateCompleted)
+				})
+			})
+		})
 	})
 
 	Convey("Given a dataset edition task executor with a zebedee client mock that returns a dataset with multiple versions", t, func() {

--- a/executor/task_dataset_series.go
+++ b/executor/task_dataset_series.go
@@ -157,6 +157,15 @@ func (e *DatasetSeriesTaskExecutor) Publish(ctx context.Context, task *domain.Ta
 // PostPublish handles post-publish operations for a dataset series task.
 func (e *DatasetSeriesTaskExecutor) PostPublish(ctx context.Context, task *domain.Task) error {
 	// Implementation of post-publish for static dataset
+	logData := log.Data{"task_id": task.ID, "job_number": task.JobNumber}
+	log.Info(ctx, "updating task state to completed", logData)
+
+	err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StateCompleted)
+	if err != nil {
+		log.Error(ctx, "failed to update task state to completed", err, logData)
+		return err
+	}
+	log.Info(ctx, "successfully updated task state to completed", logData)
 	return nil
 }
 

--- a/executor/task_dataset_series_test.go
+++ b/executor/task_dataset_series_test.go
@@ -154,6 +154,20 @@ func TestDatasetSeriesTaskExecutor(t *testing.T) {
 				})
 			})
 		})
+
+		Convey("When post-publish is called for a task", func() {
+			err := executor.PostPublish(ctx, testSeriesTask)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+
+				Convey("And the task state is updated to completed", func() {
+					So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 1)
+					So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, testSeriesTask.ID)
+					So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StateCompleted)
+				})
+			})
+		})
 	})
 
 	Convey("Given a dataset series task executor with a zebedee client mock errors", t, func() {

--- a/executor/task_dataset_version.go
+++ b/executor/task_dataset_version.go
@@ -244,6 +244,15 @@ func (e *DatasetVersionTaskExecutor) Publish(ctx context.Context, task *domain.T
 // PostPublish handles the post-publish operations for a dataset version task.
 func (e *DatasetVersionTaskExecutor) PostPublish(ctx context.Context, task *domain.Task) error {
 	// Implementation of post-publish for dataset version
+	logData := log.Data{"task_id": task.ID, "job_number": task.JobNumber}
+	log.Info(ctx, "updating task state to completed", logData)
+
+	err := e.jobService.UpdateTaskState(ctx, task.ID, domain.StateCompleted)
+	if err != nil {
+		log.Error(ctx, "failed to update task state to completed", err, logData)
+		return err
+	}
+	log.Info(ctx, "successfully updated task state to completed", logData)
 	return nil
 }
 

--- a/executor/task_dataset_version_test.go
+++ b/executor/task_dataset_version_test.go
@@ -931,3 +931,50 @@ func TestDatasetVersionTaskExecutorPublish(t *testing.T) {
 		})
 	})
 }
+
+func TestDatasetVersionTaskExecutorPostPublish(t *testing.T) {
+	Convey("Given a job service that does not error", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error {
+				return nil
+			},
+		}
+
+		ctx := context.Background()
+		executor := NewDatasetVersionTaskExecutor(mockJobService, &clients.ClientList{}, testServiceAuthToken)
+
+		Convey("When post-publish is called for a task", func() {
+			err := executor.PostPublish(ctx, testVersionTask)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+
+				Convey("And the task state is updated to completed", func() {
+					So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 1)
+					So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, testVersionTask.ID)
+					So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StateCompleted)
+				})
+			})
+		})
+	})
+
+	Convey("Given a job service that errors when updating task state", t, func() {
+		mockJobService := &applicationMocks.JobServiceMock{
+			UpdateTaskStateFunc: func(ctx context.Context, taskID string, state domain.State) error {
+				return errTest
+			},
+		}
+
+		ctx := context.Background()
+		executor := NewDatasetVersionTaskExecutor(mockJobService, &clients.ClientList{}, testServiceAuthToken)
+
+		Convey("When post-publish is called for a task", func() {
+			err := executor.PostPublish(ctx, testVersionTask)
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldEqual, errTest)
+				So(mockJobService.UpdateTaskStateCalls(), ShouldHaveLength, 1)
+			})
+		})
+	})
+}

--- a/features/publish_static_dataset.feature
+++ b/features/publish_static_dataset.feature
@@ -71,7 +71,7 @@ Feature: Publish a static dataset job
       """
     Then the HTTP status code should be "204"
     # Post-publish runs automatically once job reaches published state
-    And I wait 2 seconds for the job processor to process tasks and jobs
+    And I wait 5 seconds for the job processor to process tasks and jobs
     When I GET "/v1/migration-jobs/30"
     Then I should receive the following JSON response with status "200":
       """

--- a/migrator/tasks.go
+++ b/migrator/tasks.go
@@ -97,6 +97,8 @@ func (mig *migrator) executeTask(ctx context.Context, task *domain.Task) {
 			err = taskExecutor.Migrate(ctx, task)
 		case domain.StatePublishing:
 			err = taskExecutor.Publish(ctx, task)
+		case domain.StatePostPublishing:
+			err = taskExecutor.PostPublish(ctx, task)
 		case domain.StateReverting:
 			err = taskExecutor.Revert(ctx, task)
 		default:

--- a/migrator/tasks_test.go
+++ b/migrator/tasks_test.go
@@ -88,6 +88,27 @@ func TestMigratorExecuteTask(t *testing.T) {
 			})
 		})
 
+		Convey("When a task in state post_publishing is executed", func() {
+			mockTestExecutor.PostPublishFunc = func(ctx context.Context, task *domain.Task) error {
+				return nil
+			}
+
+			task := &domain.Task{
+				ID:        fakeTaskID,
+				JobNumber: 101,
+				Type:      fakeTaskType,
+				State:     domain.StatePostPublishing,
+			}
+
+			mig.executeTask(context.Background(), task)
+			mig.wg.Wait()
+
+			Convey("Then the executor is called to post-publish", func() {
+				So(len(mockTestExecutor.PostPublishCalls()), ShouldEqual, 1)
+				So(mockTestExecutor.PostPublishCalls()[0].Task.Type, ShouldEqual, fakeTaskType)
+			})
+		})
+
 		Convey("When a task in state reverting is executed", func() {
 			task := &domain.Task{
 				ID:        fakeTaskID,
@@ -290,6 +311,22 @@ func TestMigratorFailTask(t *testing.T) {
 			Convey("Then the job service is not called to update the task", func() {
 				So(err, ShouldNotBeNil)
 				So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 0)
+			})
+		})
+
+		Convey("When failTask is called for a task in post_publishing state", func() {
+			task := &domain.Task{
+				ID:    fakeTaskID,
+				State: domain.StatePostPublishing,
+			}
+
+			err := mig.failTask(ctx, task, errors.New("test error"), failureReasonExecutionFailed)
+
+			Convey("Then the task is transitioned to failed_post_publish", func() {
+				So(err, ShouldBeNil)
+				So(len(mockJobService.UpdateTaskStateCalls()), ShouldEqual, 1)
+				So(mockJobService.UpdateTaskStateCalls()[0].TaskID, ShouldEqual, fakeTaskID)
+				So(mockJobService.UpdateTaskStateCalls()[0].NewState, ShouldEqual, domain.StateFailedPostPublish)
 			})
 		})
 	})

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -20,13 +20,16 @@ func (e *TransitionError) Error() string {
 // allowedTransitions encodes the state machine from the design docs.
 var allowedTransitions = map[domain.State][]domain.State{
 	// happy path
-	domain.StateSubmitted:      {domain.StateMigrating, domain.StateCancelled},
-	domain.StateMigrating:      {domain.StateInReview, domain.StateFailedMigration},
-	domain.StateInReview:       {domain.StateApproved, domain.StateRejected},
-	domain.StateApproved:       {domain.StatePublishing},
-	domain.StatePublishing:     {domain.StatePublished, domain.StateFailedPublish},
-	domain.StatePublished:      {domain.StatePostPublishing},
-	domain.StatePostPublishing: {domain.StateCompleted, domain.StateFailedPostPublish},
+	domain.StateSubmitted:  {domain.StateMigrating, domain.StateCancelled},
+	domain.StateMigrating:  {domain.StateInReview, domain.StateFailedMigration},
+	domain.StateInReview:   {domain.StateApproved, domain.StateRejected},
+	domain.StateApproved:   {domain.StatePublishing},
+	domain.StatePublishing: {domain.StatePublished, domain.StateFailedPublish},
+	// StatePendingPostPublish is a state only for tasks,
+	// and it is used to trigger the PostPublish steps for all tasks.
+	domain.StatePublished:          {domain.StatePendingPostPublish, domain.StatePostPublishing},
+	domain.StatePendingPostPublish: {domain.StatePostPublishing},
+	domain.StatePostPublishing:     {domain.StateCompleted, domain.StateFailedPostPublish},
 
 	// rejection and revert paths
 	domain.StateRejected:  {domain.StateReverting},

--- a/statemachine/statemachine_test.go
+++ b/statemachine/statemachine_test.go
@@ -70,8 +70,20 @@ func TestCanTransition(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "published to pending_post_publish is valid",
+			from:     domain.StatePublished,
+			to:       domain.StatePendingPostPublish,
+			expected: true,
+		},
+		{
 			name:     "published to post_publishing is valid",
 			from:     domain.StatePublished,
+			to:       domain.StatePostPublishing,
+			expected: true,
+		},
+		{
+			name:     "pending_post_publish to post_publishing is valid",
+			from:     domain.StatePendingPostPublish,
 			to:       domain.StatePostPublishing,
 			expected: true,
 		},
@@ -328,6 +340,11 @@ func TestIsTerminalState(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "pending_post_publish is not terminal",
+			state:    domain.StatePendingPostPublish,
+			expected: false,
+		},
+		{
 			name:     "post_publishing is not terminal",
 			state:    domain.StatePostPublishing,
 			expected: false,
@@ -379,6 +396,21 @@ func TestGetNextStates(t *testing.T) {
 			name:     "approved has one next state",
 			state:    domain.StateApproved,
 			expected: []domain.State{domain.StatePublishing},
+		},
+		{
+			name:     "published has two next states",
+			state:    domain.StatePublished,
+			expected: []domain.State{domain.StatePendingPostPublish, domain.StatePostPublishing},
+		},
+		{
+			name:     "pending_post_publish has one next state",
+			state:    domain.StatePendingPostPublish,
+			expected: []domain.State{domain.StatePostPublishing},
+		},
+		{
+			name:     "post_publishing has two next states",
+			state:    domain.StatePostPublishing,
+			expected: []domain.State{domain.StateCompleted, domain.StateFailedPostPublish},
 		},
 		{
 			name:     "completed has no next states",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -293,6 +293,7 @@ parameters:
       # Running states
       - migrating
       - publishing
+      - pending_post_publish
       - post_publishing
       - reverting
       # Failed states


### PR DESCRIPTION
### What

Adjusted post publish functionality
- Tasks now update their state in their own files
- New state of pending post publish -> this is to allow the task to then move to post_publishing and trigger the .PostPublish functionality
- This should also now allow for the Slack notification to trigger when a job state is updated to completed

### How to review

Sense check, can *optionally*:
- Pull this branch
- Run the migration stack
- Post the demo job
- make a PUT request to update the job's state once it's `in_review`:

`http://localhost:30100/v1/migration-jobs/1/state`
with the body being:
`{
    "state": "approved"
}`

- GET the job, and it's state should now be `completed`
- GET the tasks `http://localhost:30100/v1/migration-jobs/1/tasks` and they should now be `completed`
- Check the collection on disk (dp-zebedee-content/generated/publishing/zebedee/collections), and it should now show:
`"publishComplete": true,`

### Who can review

!me