### PR TITLE
Add logs to help time migration jobs

### DIFF
--- a/executor/job_static_dataset.go
+++ b/executor/job_static_dataset.go
@@ -32,7 +32,7 @@ func NewStaticDatasetJobExecutor(jobService application.JobService, clientList *
 // Migrate handles the migration operations for a static dataset job.
 func (e *StaticDatasetJobExecutor) Migrate(ctx context.Context, job *domain.Job) error {
 	logData := log.Data{"job_number": job.JobNumber}
-	log.Info(ctx, "starting migration for job", logData)
+	log.Info(ctx, "starting migration for static dataset job", logData)
 
 	datasetSeriesTask := domain.NewTask(job.JobNumber)
 
@@ -72,6 +72,7 @@ func (e *StaticDatasetJobExecutor) Migrate(ctx context.Context, job *domain.Job)
 		return err
 	}
 
+	log.Info(ctx, "completed migration for static dataset job", logData)
 	return nil
 }
 
@@ -79,7 +80,7 @@ func (e *StaticDatasetJobExecutor) Migrate(ctx context.Context, job *domain.Job)
 func (e *StaticDatasetJobExecutor) Publish(ctx context.Context, job *domain.Job) error {
 	// Implementation of publish for static dataset
 	logData := log.Data{"job_number": job.JobNumber}
-	log.Info(ctx, "starting publishing for job", logData)
+	log.Info(ctx, "starting publishing for static dataset job", logData)
 
 	// approving zebedee collection
 	log.Info(ctx, "starting zebedee collection approval for job", logData)
@@ -125,7 +126,7 @@ func (e *StaticDatasetJobExecutor) Publish(ctx context.Context, job *domain.Job)
 			return err
 		}
 	}
-	log.Info(ctx, "successfully updated all job tasks state to approved", logData)
+	log.Info(ctx, "successfully updated all job tasks state to approved, completed publishing for static dataset job", logData)
 
 	return nil
 }
@@ -165,7 +166,7 @@ func (e *StaticDatasetJobExecutor) PostPublish(ctx context.Context, job *domain.
 			return err
 		}
 	}
-	log.Info(ctx, "successfully updated all job tasks state to pending post-publish", logData)
+	log.Info(ctx, "successfully updated all job tasks state to pending post-publish, completed post-publishing for job", logData)
 
 	return nil
 }

--- a/executor/job_static_dataset.go
+++ b/executor/job_static_dataset.go
@@ -72,7 +72,7 @@ func (e *StaticDatasetJobExecutor) Migrate(ctx context.Context, job *domain.Job)
 		return err
 	}
 
-	log.Info(ctx, "completed migration for static dataset job", logData)
+	log.Info(ctx, "migration task created successfully", logData)
 	return nil
 }
 
@@ -126,7 +126,7 @@ func (e *StaticDatasetJobExecutor) Publish(ctx context.Context, job *domain.Job)
 			return err
 		}
 	}
-	log.Info(ctx, "successfully updated all job tasks state to approved, completed publishing for static dataset job", logData)
+	log.Info(ctx, "successfully updated all job tasks state to approved", logData)
 
 	return nil
 }
@@ -166,7 +166,7 @@ func (e *StaticDatasetJobExecutor) PostPublish(ctx context.Context, job *domain.
 			return err
 		}
 	}
-	log.Info(ctx, "successfully updated all job tasks state to pending post-publish, completed post-publishing for job", logData)
+	log.Info(ctx, "successfully updated all job tasks state to pending post-publish", logData)
 
 	return nil
 }

--- a/migrator/jobs.go
+++ b/migrator/jobs.go
@@ -85,7 +85,7 @@ func (mig *migrator) monitorJobs(ctx context.Context) {
 func (mig *migrator) executeJob(ctx context.Context, job *domain.Job) {
 	requestID := dpRequest.NewRequestID(RequestIDLength)
 	ctx = dpRequest.WithRequestId(ctx, requestID)
-	log.Info(ctx, "started executing job", log.Data{"job_id": job.ID, "job_state": job.State})
+	log.Info(ctx, "executing job", log.Data{"job_id": job.ID, "job_state": job.State})
 	mig.wg.Add(1)
 	go func() {
 		defer mig.wg.Done()
@@ -125,7 +125,6 @@ func (mig *migrator) executeJob(ctx context.Context, job *domain.Job) {
 			_ = mig.failJob(ctx, job, err, failureReasonExecutionFailed)
 		}
 	}()
-	log.Info(ctx, "finished executing job", log.Data{"job_id": job.ID, "job_state": job.State})
 }
 
 func (mig *migrator) failJob(ctx context.Context, job *domain.Job, originalErr error, failureReason string) error {

--- a/migrator/jobs.go
+++ b/migrator/jobs.go
@@ -85,7 +85,7 @@ func (mig *migrator) monitorJobs(ctx context.Context) {
 func (mig *migrator) executeJob(ctx context.Context, job *domain.Job) {
 	requestID := dpRequest.NewRequestID(RequestIDLength)
 	ctx = dpRequest.WithRequestId(ctx, requestID)
-	log.Info(ctx, "executing job", log.Data{"job_id": job.ID, "job_state": job.State})
+	log.Info(ctx, "started executing job", log.Data{"job_id": job.ID, "job_state": job.State})
 	mig.wg.Add(1)
 	go func() {
 		defer mig.wg.Done()
@@ -125,6 +125,7 @@ func (mig *migrator) executeJob(ctx context.Context, job *domain.Job) {
 			_ = mig.failJob(ctx, job, err, failureReasonExecutionFailed)
 		}
 	}()
+	log.Info(ctx, "finished executing job", log.Data{"job_id": job.ID, "job_state": job.State})
 }
 
 func (mig *migrator) failJob(ctx context.Context, job *domain.Job, originalErr error, failureReason string) error {

--- a/migrator/state_transition_rule.go
+++ b/migrator/state_transition_rule.go
@@ -149,7 +149,9 @@ func (mig *migrator) transitionJobFailure(ctx context.Context, job *domain.Job, 
 }
 
 func (mig *migrator) transitionJobSuccess(ctx context.Context, job *domain.Job, rule StateTransitionRule) error {
-	log.Info(ctx, "attempting to transition job to next state")
+	log.Info(ctx, "attempting to transition job to next state", log.Data{
+		"job_number": job.JobNumber,
+	})
 
 	transitioned, err := mig.transitionJob(ctx, job, rule.TargetState)
 	if err != nil {

--- a/migrator/state_transition_rule.go
+++ b/migrator/state_transition_rule.go
@@ -149,11 +149,7 @@ func (mig *migrator) transitionJobFailure(ctx context.Context, job *domain.Job, 
 }
 
 func (mig *migrator) transitionJobSuccess(ctx context.Context, job *domain.Job, rule StateTransitionRule) error {
-	log.Info(ctx, "transitioning job to next state", log.Data{
-		"job_number":    job.JobNumber,
-		"job_old_state": job.State,
-		"job_new_state": rule.TargetState,
-	})
+	log.Info(ctx, "attempting to transition job to next state")
 
 	transitioned, err := mig.transitionJob(ctx, job, rule.TargetState)
 	if err != nil {
@@ -179,6 +175,7 @@ func (mig *migrator) transitionJobSuccess(ctx context.Context, job *domain.Job, 
 }
 
 func (mig *migrator) transitionJob(ctx context.Context, job *domain.Job, targetState domain.State) (bool, error) {
+	var oldJobState = job.State
 	err := mig.jobService.UpdateJobState(ctx, job.JobNumber, targetState, "")
 	if errors.Is(err, appErrors.ErrStateAlreadyAtTarget) {
 		log.Info(ctx, "transitionJob: job is already in the target state, no transition needed", log.Data{
@@ -202,6 +199,11 @@ func (mig *migrator) transitionJob(ctx context.Context, job *domain.Job, targetS
 		}
 		return false, err
 	}
+	log.Info(ctx, "transitioned job to next state", log.Data{
+		"job_number":    job.JobNumber,
+		"job_old_state": oldJobState,
+		"job_new_state": job.State,
+	})
 	return true, nil
 }
 

--- a/migrator/state_transition_rule.go
+++ b/migrator/state_transition_rule.go
@@ -149,6 +149,12 @@ func (mig *migrator) transitionJobFailure(ctx context.Context, job *domain.Job, 
 }
 
 func (mig *migrator) transitionJobSuccess(ctx context.Context, job *domain.Job, rule StateTransitionRule) error {
+	log.Info(ctx, "transitioning job to next state", log.Data{
+		"job_number":    job.JobNumber,
+		"job_old_state": job.State,
+		"job_new_state": rule.TargetState,
+	})
+
 	transitioned, err := mig.transitionJob(ctx, job, rule.TargetState)
 	if err != nil {
 		log.Error(ctx, "failed to update job state", err)


### PR DESCRIPTION
### What

Added some logs so that we can more easily calculate the time between the start and end of migration jobs e.g., for doing performance testing.

### How to review

Sense check.

### Who can review

Anyone.