### PR TITLE
Log the old and new job states correctly

### DIFF
--- a/migrator/state_transition_rule.go
+++ b/migrator/state_transition_rule.go
@@ -177,7 +177,6 @@ func (mig *migrator) transitionJobSuccess(ctx context.Context, job *domain.Job, 
 }
 
 func (mig *migrator) transitionJob(ctx context.Context, job *domain.Job, targetState domain.State) (bool, error) {
-	var oldJobState = job.State
 	err := mig.jobService.UpdateJobState(ctx, job.JobNumber, targetState, "")
 	if errors.Is(err, appErrors.ErrStateAlreadyAtTarget) {
 		log.Info(ctx, "transitionJob: job is already in the target state, no transition needed", log.Data{
@@ -203,8 +202,8 @@ func (mig *migrator) transitionJob(ctx context.Context, job *domain.Job, targetS
 	}
 	log.Info(ctx, "transitioned job to next state", log.Data{
 		"job_number":    job.JobNumber,
-		"job_old_state": oldJobState,
-		"job_new_state": job.State,
+		"job_old_state": job.State, // the state of this Job object will still be the old state, but the job in Mongo will now have the new state
+		"job_new_state": targetState,
 	})
 	return true, nil
 }


### PR DESCRIPTION
### What

Changed the logging of transitioning the job to the next state so that it shows the old and new states correctly; currently it shows the old state twice so this has been amended.
 
### How to review

Sense check.

### Who can review

Anyone.